### PR TITLE
Apply fading out steps to Portal

### DIFF
--- a/_about/about.md
+++ b/_about/about.md
@@ -1,6 +1,7 @@
 ---
 permalink: /about/
 title: "Welcome to Tizen .NET Portal"
+redirect_to: https://developer.samsung.com/tizen/About-Tizen.NET/Tizen.NET.html
 ---
 
 <br/>

--- a/_config.yml
+++ b/_config.yml
@@ -234,6 +234,7 @@ plugins:
   - jekyll-feed
   - jemoji
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -243,6 +244,7 @@ whitelist:
   - jekyll-feed
   - jemoji
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 
 # Archives

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,17 +1,17 @@
 # main links
 main:
-  - title: "About"
-    url: /about/
-  - title: "Quick Guides"
-    url: /guides/
-  - title: "Posts"
-    url: /posts/
-  - title: "Known Issues"
-    url: /issues/
-  - title: "Resources"
-    url: /resources/
-  - title: "FAQ"
-    url: /faq/
+#  - title: "About"
+#    url: /about/
+#  - title: "Quick Guides"
+#    url: /guides/
+#  - title: "Posts"
+#    url: /posts/
+#  - title: "Known Issues"
+#    url: /issues/
+#  - title: "Resources"
+#    url: /resources/
+#  - title: "FAQ"
+#    url: /faq/
 
 
 # quick guides links

--- a/_faq/FAQ.md
+++ b/_faq/FAQ.md
@@ -1,6 +1,7 @@
 ---
 title: "FAQ"
 permalink: /faq/
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 FAQs are here to help solve the various issues you may face while developing Tizen .NET applications.

--- a/_faq/general-baselinesdk.md
+++ b/_faq/general-baselinesdk.md
@@ -3,6 +3,7 @@ title:  "Tizen Baseline SDK"
 permalink: /faq/baseline-sdk/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## JDK version error

--- a/_faq/general-contribution.md
+++ b/_faq/general-contribution.md
@@ -2,6 +2,7 @@
 title:  "How to Contribute"
 permalink: /faq/contribution/
 classes: wide
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## Contributions

--- a/_faq/general-poartal.md
+++ b/_faq/general-poartal.md
@@ -1,6 +1,7 @@
 ---
 title:  "Tizen .NET Portal"
 permalink: /faq/portal/
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## What is the Tizen .NET portal?

--- a/_faq/general-questions.md
+++ b/_faq/general-questions.md
@@ -1,6 +1,7 @@
 ---
 title: "Issues and Questions"
 permalink: /faq/questions/
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 Do you have any questions about Tizen .NET? Did you find any issues? If so, you can open a request at the Tizen .NET GitHub.

--- a/_faq/general-techsupport.md
+++ b/_faq/general-techsupport.md
@@ -1,6 +1,7 @@
 ---
 title: "Technical Support"
 permalink: /faq/tech-support/
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ### Technical Support

--- a/_faq/general-usingmac.md
+++ b/_faq/general-usingmac.md
@@ -3,6 +3,7 @@ title:  "Using Mac"
 permalink: /faq/mac/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## Parallels

--- a/_faq/tv-howtodebug.md
+++ b/_faq/tv-howtodebug.md
@@ -1,6 +1,7 @@
 ---
 title:  "How to Debug?"
 permalink: /faq/tv/howtodebug/
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/FAQ/FAQ.html
 ---
 
 Debug mode for [2018 Samsung Smart TV models](https://developer.samsung.com/tv/develop/specifications/tv-model-groups) is not supported.

--- a/_faq/wearable-howtodebug.md
+++ b/_faq/wearable-howtodebug.md
@@ -1,6 +1,7 @@
 ---
 title:  "How to Debug?"
 permalink: /faq/wearable/howtodebug/
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## Debug a Tizen .NET application

--- a/_faq/wearable-review.md
+++ b/_faq/wearable-review.md
@@ -1,6 +1,7 @@
 ---
 title:  "Design Review Process"
 permalink: /faq/wearable/design-review/
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## Submit your design

--- a/_issues/issues.md
+++ b/_issues/issues.md
@@ -2,6 +2,7 @@
 title: "Known Issues"
 permalink: /issues/
 toc: false
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 You may face issues when developing Tizen .NET applications.

--- a/_issues/tv-2018-issues.md
+++ b/_issues/tv-2018-issues.md
@@ -5,6 +5,7 @@ search: true
 toc: true
 toc_sticky: true
 toc_label: Known Issues & Workarounds
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/FAQ/FAQ.html
 ---
 
 This section lists problems you might encounter while working with a Tizen TV emulator or a Samsung Smart TV.

--- a/_issues/tv-api-limitations.md
+++ b/_issues/tv-api-limitations.md
@@ -5,6 +5,7 @@ search: true
 toc: true
 toc_label: TV API Limitations
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/FAQ/FAQ.html
 ---
 
 ## .NET Standard

--- a/_issues/tv-behaviors.md
+++ b/_issues/tv-behaviors.md
@@ -3,6 +3,7 @@ title:  "Behaviors"
 permalink: /issues/tv/behaviors/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/FAQ/FAQ.html
 ---
 
 ### Xamarin.Forms WebView

--- a/_issues/tv-tools-vs.md
+++ b/_issues/tv-tools-vs.md
@@ -3,6 +3,7 @@ title:  "Visual Studio 2019"
 permalink: /issues/tv/tools-vs/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/FAQ/FAQ.html
 ---
 
 This issue was shared on March 23, 2019.

--- a/_issues/tv-tools-vscode.md
+++ b/_issues/tv-tools-vscode.md
@@ -3,6 +3,7 @@ title:  "Visual Studio Code"
 permalink: /issues/tv/tools-vscode/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/FAQ/FAQ.html
 ---
 
 Visual Studio 2017 on Windows is the number one choice for developing Tizen .NET applications. However, if you are a Mac user, you have the option of using Visual Studio Code to develop Tizen .NET applications.

--- a/_issues/wearable-api-limitations.md
+++ b/_issues/wearable-api-limitations.md
@@ -5,6 +5,7 @@ search: true
 toc: true
 toc_label: Wearable API Limitations
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## .NET Standard

--- a/_issues/wearable-behaviors.md
+++ b/_issues/wearable-behaviors.md
@@ -3,6 +3,7 @@ title:  "Behaviors"
 permalink: /issues/wearable/behaviors/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## MediaView support

--- a/_issues/wearable-tools-tizenstudio.md
+++ b/_issues/wearable-tools-tizenstudio.md
@@ -5,6 +5,7 @@ search: true
 toc: true
 toc_sticky: true
 toc_label: Known Issues and Workarounds
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 ## Connection issue between a watch and Device Manager

--- a/_issues/wearable-tools-vs.md
+++ b/_issues/wearable-tools-vs.md
@@ -3,6 +3,7 @@ title:  "Visual Studio 2019"
 permalink: /issues/wearable/tools-vs/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 This issue was shared on March 23, 2019.

--- a/_issues/wearable-tools-vscode.md
+++ b/_issues/wearable-tools-vscode.md
@@ -3,6 +3,7 @@ title:  "Visual Studio Code"
 permalink: /issues/wearable/tools-vscode/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 Visual Studio 2017 on Windows is the number one choice for developing Tizen .NET applications. However, if you are a Mac user, you have the option of using Visual Studio Code to develop Tizen .NET applications. See [Installing Visual Studio Code Extension for Tizen](https://developer.tizen.org/development/visual-studio-code-extension-tizen/installing-visual-studio-code-extension-tizen) for information about the Tizen .NET extension.

--- a/_issues/wearable-watchface.md
+++ b/_issues/wearable-watchface.md
@@ -3,6 +3,7 @@ title:  "Watch Face"
 permalink: /issues/wearable/watchface/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/FAQ/FAQ.html
 ---
 
 

--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -4,4 +4,5 @@ layout: categories
 permalink: /categories/
 category_bar: true
 category_bar_sticky: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---

--- a/_pages/category-environment.md
+++ b/_pages/category-environment.md
@@ -5,4 +5,5 @@ permalink: /categories/environment/
 taxonomy: Environment
 category_bar: true
 category_bar_sticky: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---

--- a/_pages/category-smart-tvs.md
+++ b/_pages/category-smart-tvs.md
@@ -5,4 +5,5 @@ permalink: /categories/smart-tvs/
 taxonomy: Smart TVs
 category_bar: true
 category_bar_sticky: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---

--- a/_pages/category-tizen-net.md
+++ b/_pages/category-tizen-net.md
@@ -5,4 +5,5 @@ permalink: /categories/tizen-net/
 taxonomy: Tizen .NET
 category_bar: true
 category_bar_sticky: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---

--- a/_pages/category-wearables.md
+++ b/_pages/category-wearables.md
@@ -5,4 +5,5 @@ permalink: /categories/wearables/
 taxonomy: Wearables
 category_bar: true
 category_bar_sticky: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---

--- a/_pages/category-xamarinforms.md
+++ b/_pages/category-xamarinforms.md
@@ -5,4 +5,5 @@ permalink: /categories/xamarinforms/
 taxonomy: Xamarin.Forms
 tagbar: true
 tagbar_sticky: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -4,9 +4,8 @@ permalink: /
 header:
   overlay_color: "#5e616c"
 excerpt: >
-  Welcome to the Tizen .NET Portal!<br/>
-  Everything you need for developing Tizen .NET applications is available here.<br/>
-  To get started, see the [Set Up the Environment](guides/environment) guide.
+  Tizen .NET Portal is integrated to [Samsung Developers](https://developer.samsung.com/tizen)<br/>
+  Please visit [Samsung Developers](https://developer.samsung.com/tizen) to learn about Tizen .NET.<br/>
 feature_row:
   - image_path: /assets/images/home/samsung-developers-logo.png
     alt: "Samsung Developers"

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -4,6 +4,7 @@ title: "All Posts"
 layout: posts
 category_bar: true
 category_bar_sticky: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---
 
 {% capture written_label %}'None'{% endcapture %}

--- a/_pages/samples.md
+++ b/_pages/samples.md
@@ -1,6 +1,7 @@
 ---
 permalink: /samples/
 title: "Sample Collections"
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Resources/Resources.html
 ---
 
 # Sample Collections

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -3,4 +3,5 @@ title: "Posts by Tag"
 permalink: /tags/
 layout: tags
 author_profile: true
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---

--- a/_posts/2019-01-02-welcome-to-tizen-posts.md
+++ b/_posts/2019-01-02-welcome-to-tizen-posts.md
@@ -3,6 +3,7 @@ title:  "Welcome to Tizen .NET Posts"
 date:   2019-01-02
 categories:
   - Tizen .NET
+redirect_to: https://developer.samsung.com/blog/en-us/
 ---
 
 Welcome to Tizen .NET Posts!

--- a/_posts/2019-01-04-How-to-package-UI-and-service-apps.md
+++ b/_posts/2019-01-04-How-to-package-UI-and-service-apps.md
@@ -7,6 +7,7 @@ categories:
   - Tizen .NET
 last_modified_at: 2019-01-04
 author: Juwon (Julia) Ahn
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/01/04/how-to-package-ui-and-service-applications-together-and-perform-them
 ---
 
 ## Create a new Tizen project for Xamarin.Forms application

--- a/_posts/2019-01-16-tizen-baseline-sdk.md
+++ b/_posts/2019-01-16-tizen-baseline-sdk.md
@@ -4,6 +4,7 @@ author: Jay Cho
 categories:
   - Environment
 tag: SDK
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/01/16/install-tizen-baseline-sdk
 ---
 
 ## Overview

--- a/_posts/2019-01-24-tv-emul-v5.md
+++ b/_posts/2019-01-24-tv-emul-v5.md
@@ -6,6 +6,7 @@ categories:
 tags: TV Emulator
 last_modified_at: 2019-01-24
 author: Juwon (Julia) Ahn
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/01/24/launch-your-tizen-net-application-on-a-samsung-tv-50-emulator
 ---
 
 Tizen .NET applications can be launched through **APPS** on the Samsung TV 5.0 emulator.

--- a/_posts/2019-01-28-sdc2018.md
+++ b/_posts/2019-01-28-sdc2018.md
@@ -6,6 +6,7 @@ categories:
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/01/28/sdc-2018-recap-from-the-tizen-team
 ---
 
 

--- a/_posts/2019-02-12-custom-fonts.md
+++ b/_posts/2019-02-12-custom-fonts.md
@@ -7,6 +7,7 @@ last_modified_at: 2019-02-12
 author: Juwon (Julia) Ahn
 toc: true
 toc_label: Custom Fonts in Tizen .Net Apps
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/02/12/use-custom-fonts-in-tizen-net-apps
 ---
 
 ## Xamarin.Forms application

--- a/_posts/2019-02-14-Developing-GalaxyWatch-App-using-CircularUI.md
+++ b/_posts/2019-02-14-Developing-GalaxyWatch-App-using-CircularUI.md
@@ -6,6 +6,7 @@ last_modified_at: 2019-02-15
 author: Jeongkyun Pu
 toc: true
 toc_label: Developing Galaxy Watch App using CircularUI
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/02/14/develop-galaxy-watch-apps-using-circularui
 ---
 
 Tizen .NET has three types of application models:

--- a/_posts/2019-02-19-launch-your-.net-application-on-samsung-smart-tv.md
+++ b/_posts/2019-02-19-launch-your-.net-application-on-samsung-smart-tv.md
@@ -6,6 +6,7 @@ last_modified_at: 2019-02-19
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/02/19/launch-your-tizen-net-application-on-samsung-smart-tv
 ---
 
 This post discusses how to run the Tizen .NET application with Xamarin.Forms on the Samsung Smart TV 2018 models. Learn how to run your own applications on Samsung Smart TV.

--- a/_posts/2019-02-22-building-the-tizen-net-nuget-package.md
+++ b/_posts/2019-02-22-building-the-tizen-net-nuget-package.md
@@ -4,6 +4,7 @@ last_modified_at: 2019-02-22
 categories:
   - Tizen .NET
 author: Kangho Hur
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/02/22/build-the-tizen-net-nuget-package
 ---
 
 TizenFX APIs allow you to access Tizen-specific platform features not covered by the generic .NET standard and Xamarin APIs, such as system information and status, battery status, sensor date, and account and connectivity services.

--- a/_posts/2019-03-08-How-to-use-SkiaSharp-in-Tizen-Net.md
+++ b/_posts/2019-03-08-How-to-use-SkiaSharp-in-Tizen-Net.md
@@ -6,6 +6,7 @@ categories:
 author: Rina You
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/03/08/how-to-use-skiasharp-in-tizen-net
 ---
 
 SkiaSharp is a cross-platform 2D graphics API for .NET platforms powered by the Google Skia Library. SkiaSharp provides a comprehensive API that is used on mobile, TV, watch, and desktop platforms. You can use SkiaSharp to create many different types of graphics, tables, and text in your own application.

--- a/_posts/2019-03-29-Tizen-UI-Automation-Test-using-Appium.md
+++ b/_posts/2019-03-29-Tizen-UI-Automation-Test-using-Appium.md
@@ -6,6 +6,7 @@ categories:
 author: SeungHyun Choi
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/03/29/tizen-ui-automation-test-using-appium
 ---
 
 ## What is Appium?

--- a/_posts/2019-04-10-Samsung-Galaxy-Watch-Active.md
+++ b/_posts/2019-04-10-Samsung-Galaxy-Watch-Active.md
@@ -6,6 +6,7 @@ categories:
 author: Juwon (Julia) Ahn
 search: true
 classes: wide
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/04/10/samsung-galaxy-watch-active-and-wearable-emulator-without-the-rotating-bezel
 ---
 
 Samsung Galaxy Watch Active is now available.

--- a/_posts/2019-04-15-how-to-use-the-GalaxyWatch-sensors.md
+++ b/_posts/2019-04-15-how-to-use-the-GalaxyWatch-sensors.md
@@ -7,6 +7,7 @@ author: Sungsu Kim
 toc: true
 toc_sticky: true
 toc_label: Contents
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/04/15/how-to-use-sensors-on-a-galaxy-watch
 ---
 
 Many developers have asked how to use sensor features on Galaxy Watch. This post introduces sensors that are supported for Galaxy Watch and how developers can use them.

--- a/_posts/2019-05-02-try-latest-in-tizen-net.md
+++ b/_posts/2019-05-02-try-latest-in-tizen-net.md
@@ -7,6 +7,7 @@ author: Sunghyun Min
 toc: true
 toc_sticky: true
 toc_label: Try the Latest in Tizen .NET with Nightly Builds
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/05/02/try-the-latest-in-tizen-net-with-nightly-builds
 ---
 
 TizenFX is a part of [Tizen Project](https://www.tizen.org/), which allows you to access platform-specific features not covered by the generic .NET and Xamarin.Forms. There are several versions of TizenFX, according to Tizen platform release. They have been published as Tizen.NET packages in [nuget.org](https://www.nuget.org/).

--- a/_posts/2019-05-15-how-to-debug-Tizen.NET-Application.md
+++ b/_posts/2019-05-15-how-to-debug-Tizen.NET-Application.md
@@ -6,6 +6,7 @@ categories:
 author: Reni Mathew
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/05/15/how-to-debug-tizennet-applications
 ---
 
 Debugging the Tizen .NET application is available as of Tizen 5.0.

--- a/_posts/2019-05-20-CircularUI-MediaPlayer.md
+++ b/_posts/2019-05-20-CircularUI-MediaPlayer.md
@@ -8,6 +8,7 @@ author: Juwon (Julia) Ahn
 toc: true
 toc_sticky: true
 toc_label: Video Player for Wearables
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/05/20/how-to-make-a-video-player-for-tizen-wearables
 ---
 
 You can play media files stored in Galaxy Watch, or present over the Internet in your application. In this post, we discuss how to create a video player for Tizen wearables.

--- a/_posts/2019-05-22-Bring-beautiful-Lottie-animation-to-your-Galaxy-Watch-apps.md
+++ b/_posts/2019-05-22-Bring-beautiful-Lottie-animation-to-your-Galaxy-Watch-apps.md
@@ -8,6 +8,7 @@ author: Kangho Hur
 toc: true
 toc_sticky: true
 toc_label: Lottie for Tizen .NET
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/05/22/bring-beautiful-lottie-animation-to-your-galaxy-watch-apps
 ---
 
 [Lottie](https://github.com/airbnb/lottie) is a library for Android, iOS, Web, and Windows that parses [Adobe After Effects](http://www.adobe.com/products/aftereffects.html) animations exported as JSON with [Bodymovin](https://github.com/bodymovin/bodymovin) and renders them natively on mobile devices and on the web.

--- a/_posts/2019-06-13-Using-Tizen-NET-Sdk-as-SDK-style.md
+++ b/_posts/2019-06-13-Using-Tizen-NET-Sdk-as-SDK-style.md
@@ -8,6 +8,7 @@ author: Wonyoung Choi
 toc: true
 toc_sticky: true
 toc_label: Using Tizen.NET.Sdk as SDK-style
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/06/13/using-tizennetsdk-as-sdk-style
 ---
 
 `Tizen.NET.Sdk` is a NuGet package that provides the features for creating and signing a .tpk package file. Previously, this package was added to the `.csproj` file as a `PackageReference`; in this post, I introduce a new method to add this package.

--- a/_posts/2019-07-15-whats-new-for-tizen-on-forms-410.md
+++ b/_posts/2019-07-15-whats-new-for-tizen-on-forms-410.md
@@ -7,6 +7,7 @@ last_modified_at: 2019-07-15
 author: Sunghyun Min
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/07/15/whats-new-for-tizen-on-xamarinforms-410
 ---
 
 Many new UI features were added on `Xamarin.Forms 4.0`, including Shell, CollectionView and Material Visual.<br/>

--- a/_posts/2019-07-16-Connecting-TV-and-VisualStudio.md
+++ b/_posts/2019-07-16-Connecting-TV-and-VisualStudio.md
@@ -6,6 +6,7 @@ categories:
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/07/16/connecting-smart-tv-and-visual-studio
 ---
 
 To deploy and run the application on the Samsung Smart TV, first connect your TV to Visual Studio.

--- a/_posts/2019-07-23-writing-tizen-net-applications-in-fsharp.md
+++ b/_posts/2019-07-23-writing-tizen-net-applications-in-fsharp.md
@@ -5,6 +5,7 @@ categories:
   - Tizen .NET
 author: Swift Kim
 toc: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/07/23/writing-tizen-net-applications-in-f
 ---
 
 Although C# is the only language officially supported by Tizen .NET, you can write applications in other languages such as F# and VB.NET. Ideally, applications written in interoperable .NET languages are compiled into common IL (intermediate language) code, which can be executed by any CLI-compliant runtime.

--- a/_posts/2019-08-01-introducing-xamarin-essentials-for-tizen.md
+++ b/_posts/2019-08-01-introducing-xamarin-essentials-for-tizen.md
@@ -7,6 +7,7 @@ author: Sungsu Kim
 toc: true
 toc_sticky: true
 toc_label: Contents
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/08/01/introducing-xamarin-essentials-for-tizen
 ---
 
 <br/>

--- a/_posts/2019-08-08-Adding a splash screen to your Tizen .NET application.md
+++ b/_posts/2019-08-08-Adding a splash screen to your Tizen .NET application.md
@@ -8,6 +8,7 @@ last_modified_at: 2019-08-08
 toc: true
 toc_sticky: true
 toc_label: Add a splash screen to your Tizen .NET application
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/08/08/add-a-splash-screen-to-your-tizen-net-application
 ---
 
 A splash screen appears instantly while your app launches and is quickly replaced with the app's first screen. Tizen provides an option for users to include splash screens in their applications. Splash screens can be customized based on orientation and resolution.

--- a/_posts/2019-08-14-web-proxy.md
+++ b/_posts/2019-08-14-web-proxy.md
@@ -7,6 +7,7 @@ author: Juwon (Julia) Ahn
 toc: true
 toc_sticky: true
 toc_label: Access the Internet
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/08/14/use-web-proxy-to-access-the-internet-when-a-samsung-galaxy-watch-and-a-phone-are-connected-with-bluetooth
 ---
 
 You can connect to the Internet or communicate with other devices after you set up a network. When Galaxy Watch is not connected to a mobile phone, you can still be connected to the Internet through the watch's Wi-Fi or cellular network.

--- a/_posts/2019-09-02-Significant-change-from-Xamarin.Forms-4.2.0.md
+++ b/_posts/2019-09-02-Significant-change-from-Xamarin.Forms-4.2.0.md
@@ -6,6 +6,7 @@ categories:
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/09/02/changes-to-tizennet-from-xamarinforms-420
 ---
 
 `Xamarin.Forms 4.2.0` has been released, with significant changes on the Tizen platform.

--- a/_posts/2019-09-16-how-to-set-image-borders.md
+++ b/_posts/2019-09-16-how-to-set-image-borders.md
@@ -7,6 +7,7 @@ author: Sunghyun Min
 toc: true
 toc_sticky: true
 toc_label: How to set image borders
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/09/16/how-to-set-an-images-borders-to-make-it-resizable
 ---
 
 Sometimes app developers want to set a resizable image as background to better fit the contents. However, if you resize the image as it is, you may not get the shape you want.<br/>

--- a/_posts/2019-10-02-Add-Tizen-project.md
+++ b/_posts/2019-10-02-Add-Tizen-project.md
@@ -6,6 +6,7 @@ categories:
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/10/02/add-a-tizen-project-to-xamarinforms-applications
 ---
 
 This article provide helpful information for new Tizen .NET application developers to get started.

--- a/_posts/2019-10-14-Update-TizenNETSdk-package.md
+++ b/_posts/2019-10-14-Update-TizenNETSdk-package.md
@@ -6,6 +6,7 @@ categories:
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/10/14/update-tizennetsdk-package-in-visual-studio-163-or-above
 ---
 
 <b>Visual Studio 2019 version 16.3</b> has been recently released and lots of people would be very happy to update their Visual Studio to the latest.

--- a/_posts/2019-11-05-Releasing-VS-Mac-Tizen-extension.md
+++ b/_posts/2019-11-05-Releasing-VS-Mac-Tizen-extension.md
@@ -6,6 +6,7 @@ categories:
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/11/05/introducing-the-visual-studio-for-mac-tizen-extension
 ---
 
 I am very pleased to announce the release of the Tizen extension for Visual Studio for Mac.

--- a/_posts/2019-11-20-Samsung-Developer-Conference-2019.md
+++ b/_posts/2019-11-20-Samsung-Developer-Conference-2019.md
@@ -6,6 +6,7 @@ categories:
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/11/20/recapping-tizen-at-samsung-developer-conference-2019
 ---
 
 Samsung Developer Conference 2019 was held in San Jose, California, on Oct. 29 and 30. The conference keeps getting larger, and the Tizen zone within SDC has expanded as well. This year, not only did the Tizen .NET Team host booths and a session, but several partner booths demonstrated their real-world Tizen .NET solutions.

--- a/_posts/2019-12-02-Build-an-Widget-application-for-Galaxy-Watch.md
+++ b/_posts/2019-12-02-Build-an-Widget-application-for-Galaxy-Watch.md
@@ -7,6 +7,7 @@ last_modified_at: 2019-12-02
 author: Kangho Hur
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/12/02/build-a-widget-for-galaxy-watch
 ---
 
 The Tizen wearable profile provides three application models to create a variety of UI applications:

--- a/_posts/2019-12-16-Image-caching-with-FFImageloading.md
+++ b/_posts/2019-12-16-Image-caching-with-FFImageloading.md
@@ -7,6 +7,7 @@ last_modified_at: 2019-12-16
 author: Seungkeun Lee
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2019/12/16/image-caching-using-ffimageloading
 ---
 
 When you want to use an internet image in your application, you may be concerned about slow image loading or load failure caused by network issues. In this scenario, it is a good idea to show the default temporal image until the actual image is successfully loaded and ready to be displayed. Reusing the image data that has been downloaded can also make an image appear more quickly.

--- a/_posts/2020-01-16-grabbing-hardware-key-events.md
+++ b/_posts/2020-01-16-grabbing-hardware-key-events.md
@@ -7,6 +7,7 @@ last_modified_at: 2020-01-16
 author: Jay Cho
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2020/01/16/grabbing-hardware-key-events-in-tizen
 ---
 
 It is not a common scenario to grab a hardware key event in your application, because you can simply use controls like `Editor` or `Entry` when you need to get input from users. However, if you want to make a more advanced application which handles hardware key inputs more detail or especially when you want to do something with the Smart TV remote control key event, you want to grab hardware key events.

--- a/_posts/2020-02-03-Using-a-Custom-Font-to-Your-XamarinForms-Tizen-Application.md
+++ b/_posts/2020-02-03-Using-a-Custom-Font-to-Your-XamarinForms-Tizen-Application.md
@@ -7,6 +7,7 @@ last_modified_at: 2020-02-03
 author: Kangho Hur
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/blog/en-us/2020/02/04/using-a-custom-font-in-your-xamarinforms-tizen-application
 ---
 
 Previously, in order to use custom fonts in existing Xamarin.Forms applications, you had to add the font asset in each platform project and use the `FontFamily` property to apply the fonts. This was very cumbersome, because each platform required a different syntax for referencing a font file. 

--- a/_quickguides/about.md
+++ b/_quickguides/about.md
@@ -3,6 +3,7 @@ title:  "About Tizen .NET"
 permalink: /guides/about/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/About-Tizen.NET/Tizen.NET.html
 ---
 
 ## What is Tizen .NET?

--- a/_quickguides/create-tvapp.md
+++ b/_quickguides/create-tvapp.md
@@ -7,6 +7,7 @@ gallery:
   - image_path: "/assets/images/guides/launch_elmsharp_tv.png"
   - image_path: "/assets/images/guides/launch_nui_tv.png"
   - image_path: "/assets/images/guides/launch_xf_tv.png"
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/Quickstarts/Creating-an-application.html
 ---
 
 

--- a/_quickguides/create-wearableapp.md
+++ b/_quickguides/create-wearableapp.md
@@ -10,6 +10,7 @@ gallery:
     title: "Tizen.NUI"
   - image_path: "/assets/images/guides/launch_xf_wearable.png"
     title: "Xamarin.Forms"
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Quickstarts/Creating-an-application.html
 ---
 
 This guide describes how to create and run the basic Tizen .NET application. Visit [Create Your First Tizen Wearable .NET Application](https://developer.tizen.org/development/training/.net-application/getting-started/creating-your-first-tizen-wearable-.net-application) for complete instructions.

--- a/_quickguides/environment.md
+++ b/_quickguides/environment.md
@@ -3,6 +3,7 @@ title: "Environment"
 permalink: /guides/environment/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Installation.html
 ---
 
 The guide describes how to set up an environment where you can develop Tizen .NET applications.

--- a/_quickguides/publish-tvapp.md
+++ b/_quickguides/publish-tvapp.md
@@ -3,6 +3,7 @@ title: "Samsung Apps TV Seller Office"
 permalink: /guides/publish-tvapp/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/Quickstarts/Publishing-an-application.html
 ---
 
 ## Official Pages

--- a/_quickguides/publish-wearableapp.md
+++ b/_quickguides/publish-wearableapp.md
@@ -3,6 +3,7 @@ title: "Publish Your Wearable Application"
 permalink: /guides/publish-wearableapp/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Quickstarts/Publishing-an-application.html
 ---
 
 ## Samsung Galaxy Apps Seller Office

--- a/_quickguides/quickguides.md
+++ b/_quickguides/quickguides.md
@@ -3,6 +3,7 @@ title: "Tizen .NET Development"
 permalink: /guides/
 classes: wide
 comments: true
+redirect_to: https://developer.samsung.com/tizen
 ---
 
 Welcome to Tizen .NET World!

--- a/_resources/developer-sites.md
+++ b/_resources/developer-sites.md
@@ -3,6 +3,7 @@ title: "Developer Sites"
 permalink: /resources/developer-sites/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/About-Tizen.NET/Tizen.NET.html
 ---
 
 Here are some helpful resources for developing Tizen .NET applications.

--- a/_resources/devices-stores.md
+++ b/_resources/devices-stores.md
@@ -3,6 +3,7 @@ title: "Tizen Devices & Stores"
 permalink: /resources/devices-stores/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen
 ---
 
 ### Devices

--- a/_resources/doc-samsung-smart-tv.md
+++ b/_resources/doc-samsung-smart-tv.md
@@ -17,6 +17,7 @@ gallery:
     image_path: https://user-images.githubusercontent.com/1029155/42200637-4685077c-7ecf-11e8-9984-4c68048da265.gif
   - url: https://user-images.githubusercontent.com/1029155/42200638-489afd3c-7ecf-11e8-981d-8f27169ee8c0.gif
     image_path: https://user-images.githubusercontent.com/1029155/42200638-489afd3c-7ecf-11e8-981d-8f27169ee8c0.gif
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/Resources/Documents/Smart-TV.html
 ---
 
 

--- a/_resources/doc-samsung-wearables.md
+++ b/_resources/doc-samsung-wearables.md
@@ -4,6 +4,7 @@ permalink: /resources/SamsungWearables/
 toc: true
 toc_sticky: true
 toc_label: For Samsung Wearables
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Resources/Documents/Galaxy-Watch.htmlhttps://developer.samsung.com/tizen/Galaxy-Watch/Resources/Documents/Galaxy-Watch.html
 ---
 
 ## Samsung Extension APIs

--- a/_resources/doc-tizendotnet.md
+++ b/_resources/doc-tizendotnet.md
@@ -4,6 +4,7 @@ permalink: /resources/tizendotnet/
 toc: true
 toc_sticky: true
 toc_label: Tizen .NET
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Resources/Documents/Tizen.NET.html
 ---
 
 ## Tizen .NET APIs

--- a/_resources/resources.md
+++ b/_resources/resources.md
@@ -1,6 +1,7 @@
 ---
 title: "Resources"
 permalink: /resources/
+redirect_to: https://developer.samsung.com/tizen
 ---
 
 Here are some helpful resources for developing a Tizen .NET application.

--- a/_resources/sample-smart-tv.md
+++ b/_resources/sample-smart-tv.md
@@ -3,6 +3,7 @@ title: "Sample Apps for Samsung Smart TVs"
 permalink: /resources/samples_smart_tv/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Smart-TV/Resources/Samples/Smart-TV.html
 ---
 
 Here are some helpful resources to develop a Tizen .NET application for Samsung Smart TVs.

--- a/_resources/sample-tizendotnet.md
+++ b/_resources/sample-tizendotnet.md
@@ -3,6 +3,7 @@ title: "Sample Applications"
 permalink: /resources/samples_tizendotnet/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Resources/Samples/Tizen.NET.html
 ---
 
 When you first start developing a Tizen .NET application, you may be still confused about what to do.

--- a/_resources/sample-wearables.md
+++ b/_resources/sample-wearables.md
@@ -3,6 +3,7 @@ title: "Sample Apps for Samsung Wearables"
 permalink: /resources/samples_wearables/
 toc: true
 toc_sticky: true
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Resources/Samples/Galaxy-Watch.html
 ---
 
 Here are some helpful resources to develop a Tizen .NET application for Samsung Wearables.

--- a/_resources/wearables-apps-on-galaxy-store.md
+++ b/_resources/wearables-apps-on-galaxy-store.md
@@ -1,6 +1,7 @@
 ---
 title: "Tizen .NET Apps on Galaxy Store"
 permalink: /resources/dotnet_wearable_apps_on_galaxy_store/
+redirect_to: https://developer.samsung.com/tizen/Galaxy-Watch/Resources/Samples/Apps-on-store.html
 ---
 
 Here are Tizen .NET applications for Samsung Wearables.


### PR DESCRIPTION
This PR applies the fading out steps to Tizen .NET Portal.

- Update Home slogan of Portal to inform about site integration.
- Removing top menu bar from Home page.
- Adding `jekyll-redirect-from` plugin to redirect pages
- Adding redirect url to pages.

The result page will look like below
![image](https://user-images.githubusercontent.com/14328614/76828426-4319bd00-6864-11ea-8a2f-f827a837ec34.png)
