### PR TITLE
Remove unnecessary IsTrimmable property

### DIFF
--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.in.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.in.targets
@@ -24,7 +24,6 @@ Copyright (c) Samsung All rights reserved.
       TargetingPackName="Samsung.Tizen.Ref"
       TargetingPackVersion="$(_TizenFrameworkReferenceVersion)"
       Profile="Tizen"
-      IsTrimmable="true"
     />
   </ItemGroup>
 


### PR DESCRIPTION
`IsTrimmable` property is not necessary because the Samsung.Tizen provides only the framework-dependent deploy model.