### PR TITLE
Add "Run" target to run tizen application by using SDB

### DIFF
--- a/workload/Config.mk
+++ b/workload/Config.mk
@@ -7,7 +7,7 @@ DOTNET6_VERSION_BAND = $(firstword $(subst -, ,$(DOTNET6_VERSION)))
 ifeq ($(DESTDIR),)
 DOTNET6_DESTDIR = $(OUTDIR)/dotnet
 else
-DOTNET6_DESTDIR = $(DESTDIR)
+DOTNET6_DESTDIR = $(abspath $(DESTDIR))
 endif
 
 DOTNET6_MANIFESTS_DESTDIR=$(DOTNET6_DESTDIR)/sdk-manifests/$(DOTNET6_VERSION_BAND)/samsung.net.sdk.tizen

--- a/workload/Makefile
+++ b/workload/Makefile
@@ -51,30 +51,16 @@ $(eval $(call CreateNuGetPkgs,Samsung.Tizen.Templates,$(TIZEN_PACK_VERSION_FULL)
 .PHONY: packs
 packs: $(NUPKG_TARGETS)
 
-# Create NuGet.config to use generated packages
-define TEMP_NUGET_CONFIG_BODY
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-<packageSources>
-	<clear />
-	<add key="local" value="$(WORKLOAD_PACKS_OUTDIR)" />
-</packageSources>
-</configuration>
-endef
-export TEMP_NUGET_CONFIG_BODY
-
-$(TMPDIR)/NuGet.config: | $(TMPDIR)
-	@echo "$$TEMP_NUGET_CONFIG_BODY" > $@
-
 
 # Install workload to the dotnet sdk
-$(TMPDIR)/.stamp-install-workload: $(TMPDIR)/NuGet.config | $(DOTNET6_MANIFESTS_DESTDIR)
+$(TMPDIR)/.stamp-install-workload: | $(DOTNET6_MANIFESTS_DESTDIR)
 	@cp -f \
 		$(TOP)/LICENSE \
 		$(TOP)/src/Samsung.NET.Sdk.Tizen/WorkloadManifest.targets \
 		$(WORKLOAD_PACKS_OUTDIR)/workload-manifest/WorkloadManifest.json \
 		$(DOTNET6_MANIFESTS_DESTDIR)
-	@cd $(TMPDIR) && $(DOTNET6) workload install tizen --skip-manifest-update
+	@$(DOTNET6) workload install tizen --skip-manifest-update \
+		--source $(WORKLOAD_PACKS_OUTDIR) --temp-dir=$(TMPDIR)
 	@touch $@
 
 .PHONY: install

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.6.21355.2</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.7.21327.2</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.7.21327.2</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-preview.7.21379.14</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/workload/src/Samsung.NET.Sdk.Tizen/WorkloadManifest.in.json
+++ b/workload/src/Samsung.NET.Sdk.Tizen/WorkloadManifest.in.json
@@ -2,7 +2,7 @@
 	"version": "@TIZEN_PACK_VERSION@",
 	"workloads": {
 		"tizen": {
-			"description": "Tizen .NET SDK",
+			"description": ".NET SDK Workload for building Tizen applications.",
 			"packs": [
 				"Samsung.Tizen.Sdk",
 				"Samsung.Tizen.Ref",

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.After.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.After.targets
@@ -19,6 +19,7 @@ Copyright (c) Samsung All rights reserved.
   <Import Project="Samsung.Tizen.Sdk.Common.targets" />
   <Import Project="Samsung.Tizen.Sdk.NuGet.targets" />
   <Import Project="Samsung.Tizen.Sdk.Packaging.targets" />
+  <Import Project="Samsung.Tizen.Sdk.Applications.targets" Condition="'$(OutputType)'=='exe'" />
   <Import Project="Samsung.Tizen.Sdk.VisualStudio.targets" />
 
 </Project>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Applications.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Applications.targets
@@ -1,0 +1,27 @@
+<!--
+***********************************************************************************************
+Samsung.Tizen.Sdk.Applications.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) Samsung All rights reserved.
+***********************************************************************************************
+-->
+<Project>
+
+  <PropertyGroup>
+    <RunCommand>dotnet</RunCommand>
+    <RunArguments>build &quot;$(MSBuildProjectFullPath)&quot; -target:Run</RunArguments>
+  </PropertyGroup>
+
+  <Target Name="Install" DependsOnTargets="_CheckSdbToolPath;TizenPackage">
+    <Exec Command="&quot;$(SdbToolPath)sdb&quot; $(SdbTarget) install $(SignedTpkFile)" />
+  </Target>
+
+  <Target Name="Run" DependsOnTargets="Install">
+    <Exec Command="&quot;$(SdbToolPath)sdb&quot; $(SdbTarget) shell app_launcher -s %(TizenPackageFirstApplication.Identity)" />
+  </Target>
+
+</Project>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Common.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Common.targets
@@ -24,9 +24,31 @@ Copyright (c) Samsung All rights reserved.
     <DefineConstants Condition="!$(_IsTizenDefined)">__TIZEN__;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(HostOS)' == ''">
+    <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>
+    <HostOS Condition="$([MSBuild]::IsOSPlatform('linux'))">Linux</HostOS>
+    <HostOS Condition="$([MSBuild]::IsOSPlatform('osx'))">Darwin</HostOS>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_TizenSdkDefaultBaseDirectory Condition="'$(HOME)' != ''">$(HOME)</_TizenSdkDefaultBaseDirectory>
+    <_TizenSdkDefaultBaseDirectory Condition="'$(HOME)' == ''">$(HOMEDRIVE)</_TizenSdkDefaultBaseDirectory>
+    <TizenSdkDirectory Condition="'$(TizenSdkDirectory)' == ''">$(_TizenSdkDefaultBaseDirectory)\tizen-studio\</TizenSdkDirectory>
+    <SdbToolPath Condition="'$(SdbToolPath)' == ''">$(TizenSdkDirectory)tools\</SdbToolPath>
+    <SdbToolPath Condition="'$(SdbToolPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(SdbToolPath)'))</SdbToolPath>
+    <SdbToolExe Condition="'$(SdbToolExe)' == '' And '$(HostOS)' != 'Windows'">sdb</SdbToolExe>
+    <SdbToolExe Condition="'$(SdbToolExe)' == '' And '$(HostOS)' == 'Windows'">sdb.exe</SdbToolExe>
+  </PropertyGroup>
+
   <Target Name="_CheckPropertiesForTizen" BeforeTargets="BeforeBuild">
     <Error Text="Samsung.Tizen.Sdk does not support the self contained packaging. Set SelfContained to false."
            Condition="'$(SelfContained)' == 'true'" />
+  </Target>
+
+  <Target Name="_CheckSdbToolPath">
+    <Error
+        Text="$(SdbToolPath)$(SdbToolExe) not found. Please set SdbToolPath property."
+        Condition="!Exists('$(SdbToolPath)$(SdbToolExe)')" />
   </Target>
 
 </Project>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
@@ -164,9 +164,10 @@ Copyright (c) Samsung All rights reserved.
 
     <GetManifestInfo ManifestFilePath="$(TizenManifestFile)"
                      Condition="Exists('$(TizenManifestFile)')">
-      <Output TaskParameter="TpkName" PropertyName="TizenPackageName" />
-      <Output TaskParameter="TpkVersion" PropertyName="TizenPackageVersion" />
-      <Output TaskParameter="TpkExecList" ItemName="TizenPackageExecItemList" />
+      <Output TaskParameter="PackageName" PropertyName="TizenPackageName" />
+      <Output TaskParameter="PackageVersion" PropertyName="TizenPackageVersion" />
+      <Output TaskParameter="ApplicationList" ItemName="TizenPackageApplicationList" />
+      <Output TaskParameter="FirstApplication" ItemName="TizenPackageFirstApplication" />
     </GetManifestInfo>
   </Target>
 
@@ -190,18 +191,18 @@ Copyright (c) Samsung All rights reserved.
   ===========================================================================
   -->
   <Target Name="TizenCheckExecFileExist" DependsOnTargets="_TizenGetTpkInfoFromManifest">
-
     <ItemGroup>
-      <TizenPackageExecItemList Remove="%(TizenTpkAssemblyFiles.Filename)%(TizenTpkAssemblyFiles.Extension)" />
+      <_TizenPackageExecItemList Include="%(TizenPackageApplicationList.Exec)" />
+      <_TizenPackageExecItemList Remove="%(TizenTpkAssemblyFiles.Filename)%(TizenTpkAssemblyFiles.Extension)" />
     </ItemGroup>
 
     <Message Text="$(TizenManifestFile) exec file check OK"
-             Condition="@(TizenPackageExecItemList->Count()) == 0" />
+             Condition="@(_TizenPackageExecItemList->Count()) == 0" />
 
     <Error Code="TS0002"
            File="$(TizenManifestFile)"
-           Text="The '%(TizenPackageExecItemList.Identity)' file was not found.&#xA;Please check the exec attribute of $(TizenManifestFile) or check the assembly name"
-           Condition="@(TizenPackageExecItemList->Count()) != 0" />
+           Text="The '%(_TizenPackageExecItemList.Identity)' file was not found.&#xA;Please check the exec attribute of $(TizenManifestFile) or check the assembly name"
+           Condition="@(_TizenPackageExecItemList->Count()) != 0" />
   </Target>
 
   <!--


### PR DESCRIPTION
- Add a target named `Install` and `Run` to Samsung.Tizen.Sdk.Applications.targets.
- GetManifestInfo task provides the first application's information
- Bump to dotnet sdk 6.0.100-preview.7