### PR TITLE
Add scripts for installation workload manifest files

### DIFF
--- a/workload/NuGet.config
+++ b/workload/NuGet.config
@@ -7,6 +7,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/workload/scripts/README.md
+++ b/workload/scripts/README.md
@@ -2,11 +2,7 @@
 
 ## workload-install
 
-This script installs the Tizen workload manifest files to the dotnet sdk location.
-After installation by this script, other workload packs can be installed by following command:
-```
-dotnet workload install tizen --skip-manifest-update
-```
+This script installs the Tizen workload manifest files and packs to the installed dotnet sdk.
 
 ### Usage
 On Linux/MacOS:

--- a/workload/scripts/README.md
+++ b/workload/scripts/README.md
@@ -3,10 +3,13 @@
 ## workload-install
 
 This script installs the Tizen workload manifest files to the dotnet sdk location.
-After installation by this script, other workload packs can be installed by `dotnet workload install tizen` command.
+After installation by this script, other workload packs can be installed by following command:
+```
+dotnet workload install tizen --skip-manifest-update
+```
 
 ### Usage
-On Linux:
+On Linux/MacOS:
 ```
 workload-install.sh [-v <Version>] [-d <Dotnet SDK Location>]
 ```

--- a/workload/scripts/README.md
+++ b/workload/scripts/README.md
@@ -1,0 +1,26 @@
+# Scripts
+
+## workload-install
+
+This script installs the Tizen workload manifest files to the dotnet sdk location.
+After installation by this script, other workload packs can be installed by `dotnet workload install tizen` command.
+
+### Usage
+On Linux:
+```
+workload-install.sh [-v <Version>] [-d <Dotnet SDK Location>]
+```
+
+On Windows:
+```
+workload-install.ps1 [-v <Version>] [-d <Dotnet SDK Location>]
+```
+
+If this script is executed in CI environment, you can use `curl` to download the script and execute it.
+```
+curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | bash
+```
+or
+```
+curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | bash -s -- -v <version> -d <dotnet sdk location>
+```

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -60,4 +60,4 @@ Remove-Item -Path $TempDir -Force -Recurse
 
 Write-Host "Tizen manifest is installed to $TizenManifestDir."
 Write-Host ""
-Write-Host "Run 'dotnet workload install tizen' to install tizen workload packs."
+Write-Host "Run 'dotnet workload install tizen --skip-manifest-update' to install tizen workload packs."

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -1,0 +1,63 @@
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+<#
+.SYNOPSIS
+Installs Tizen workload manifest.
+.DESCRIPTION
+Installs the WorkloadManifest.json and WorkloadManifest.targets files for Tizen to the dotnet sdk.
+.PARAMETER Version
+Use specific VERSION
+.PARAMETER DotnetInstallDir
+Dotnet SDK Location installed
+#>
+
+[cmdletbinding()]
+param(
+    [Alias('v')][string]$Version="6.5.100-rc.1.92",
+    [Alias('d')][string]$DotnetInstallDir="$env:Programfiles\dotnet"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$ManifestName = "Samsung.NET.Sdk.Tizen.Manifest-6.0.100"
+$DotnetVersionBand = "6.0.100"
+
+function New-TemporaryDirectory {
+    $parent = [System.IO.Path]::GetTempPath()
+    $name = [System.IO.Path]::GetRandomFileName()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+function Test-Directory([string]$TestDir) {
+    if (-Not $(Test-Path $TestDir)) {
+        Write-Error "No target directory '$TestDir'."
+    }
+    Try {
+        [io.file]::OpenWrite($(Join-Path -Path $TestDir -ChildPath ".tmp")).Close()
+    } Catch {
+        Write-Error "No permission to install. Try run with administrator mode."
+    }
+}
+
+$ManifestDir = Join-Path -Path $DotnetInstallDir -ChildPath "sdk-manifests" | Join-Path -ChildPath $DotnetVersionBand
+$TizenManifestDir = Join-Path -Path $ManifestDir -ChildPath "samsung.net.sdk.tizen"
+Test-Directory $ManifestDir
+
+Write-Host "Installing $ManifestName/$Version to $ManifestDir..."
+
+$TempDir = $(New-TemporaryDirectory)
+$TempZipFile = Join-Path -Path $TempDir -ChildPath "manifest.zip"
+$TempUnzipDir = Join-Path -Path $TempDir -ChildPath "unzipped"
+Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/$ManifestName/$Version" -OutFile $TempZipFile
+Expand-Archive -Path $TempZipFile -DestinationPath $TempUnzipDir
+Copy-Item -Path "$TempUnzipDir\data\*" -Destination $TizenManifestDir
+Remove-Item -Path $TempDir -Force -Recurse
+
+Write-Host "Tizen manifest is installed to $TizenManifestDir."
+Write-Host ""
+Write-Host "Run 'dotnet workload install tizen' to install tizen workload packs."

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -16,7 +16,7 @@ Dotnet SDK Location installed
 
 [cmdletbinding()]
 param(
-    [Alias('v')][string]$Version="6.5.100-rc.1.92",
+    [Alias('v')][string]$Version="<latest>",
     [Alias('d')][string]$DotnetInstallDir="$env:Programfiles\dotnet"
 )
 
@@ -45,11 +45,20 @@ function Test-Directory([string]$TestDir) {
     Remove-Item -Path $(Join-Path -Path $TestDir -ChildPath ".test-write-access") -Force
 }
 
+function Get-LatestVersion([string]$Id) {
+    $Response = Invoke-WebRequest -Uri https://api.nuget.org/v3-flatcontainer/$Id/index.json | ConvertFrom-Json
+    return $Response.versions | Select-Object -Last 1
+}
+
 function Get-Package([string]$Id, [string]$Version, [string]$Destination, [string]$FileExt = "nupkg") {
     $OutFileName = "$Id.$Version.$FileExt"
     $OutFilePath = Join-Path -Path $Destination -ChildPath $OutFileName
     Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/$Id/$Version" -OutFile $OutFilePath
     return $OutFilePath
+}
+
+if ($Version -eq "<latest>") {
+    $Version = Get-LatestVersion -Id $ManifestName
 }
 
 $ManifestDir = Join-Path -Path $DotnetInstallDir -ChildPath "sdk-manifests" | Join-Path -ChildPath $DotnetVersionBand

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -38,10 +38,11 @@ function Test-Directory([string]$TestDir) {
         Write-Error "No target directory '$TestDir'."
     }
     Try {
-        [io.file]::OpenWrite($(Join-Path -Path $TestDir -ChildPath ".tmp")).Close()
+        [io.file]::OpenWrite($(Join-Path -Path $TestDir -ChildPath ".test-write-access")).Close()
     } Catch {
         Write-Error "No permission to install. Try run with administrator mode."
     }
+    Remove-Item -Path $(Join-Path -Path $TestDir -ChildPath ".test-write-access") -Force
 }
 
 $ManifestDir = Join-Path -Path $DotnetInstallDir -ChildPath "sdk-manifests" | Join-Path -ChildPath $DotnetVersionBand
@@ -55,6 +56,7 @@ $TempZipFile = Join-Path -Path $TempDir -ChildPath "manifest.zip"
 $TempUnzipDir = Join-Path -Path $TempDir -ChildPath "unzipped"
 Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/$ManifestName/$Version" -OutFile $TempZipFile
 Expand-Archive -Path $TempZipFile -DestinationPath $TempUnzipDir
+New-Item -Path $TizenManifestDir -ItemType "directory" -Force
 Copy-Item -Path "$TempUnzipDir\data\*" -Destination $TizenManifestDir
 Remove-Item -Path $TempDir -Force -Recurse
 

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -5,8 +5,8 @@
 
 #!/bin/bash -e
 
-MANIFEST_NAME=Samsung.NET.Sdk.Tizen.Manifest-6.0.100
-MANIFEST_VERSION=6.5.100-rc.1.92
+MANIFEST_NAME="samsung.net.sdk.tizen.manifest-6.0.100"
+MANIFEST_VERSION="<latest>"
 
 DOTNET_VERSION_BAND=6.0.100
 DOTNET_INSTALL_DIR=/usr/share/dotnet
@@ -42,10 +42,17 @@ while [ $# -ne 0 ]; do
     shift
 done
 
+# Check latest version of manifest.
+if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then
+    MANIFEST_VERSION=$(curl -s https://api.nuget.org/v3-flatcontainer/$MANIFEST_NAME/index.json | grep \" | tail -n 1 | tr -d '\r' | xargs)
+    if [ ! "$MANIFEST_VERSION" ]; then
+        echo "Failed to get the latest version of $MANIFEST_NAME."
+        exit 1
+    fi
+fi
+
 SDK_MANIFESTS_DIR=$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_VERSION_BAND
-
-echo "Installing $MANIFEST_NAME/$MANIFEST_VERSION to $SDK_MANIFESTS_DIR..."
-
+# Check target manifest directory.
 if [ ! -d $SDK_MANIFESTS_DIR ]; then
     echo "No target directory \`$SDK_MANIFESTS_DIR\`";
     exit 1
@@ -57,6 +64,8 @@ if [ ! -w $SDK_MANIFESTS_DIR ]; then
 fi
 
 TMPDIR=$(mktemp -d)
+
+echo "Installing $MANIFEST_NAME/$MANIFEST_VERSION to $SDK_MANIFESTS_DIR..."
 
 # Download and extract the manifest nuget package.
 curl -s -o $TMPDIR/manifest.zip -L https://www.nuget.org/api/v2/package/$MANIFEST_NAME/$MANIFEST_VERSION

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -1,0 +1,84 @@
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+#!/bin/bash -e
+
+MANIFEST_NAME=Samsung.NET.Sdk.Tizen.Manifest-6.0.100
+MANIFEST_VERSION=6.5.100-rc.1.92
+
+DOTNET_VERSION_BAND=6.0.100
+DOTNET_INSTALL_DIR=/usr/share/dotnet
+
+while [ $# -ne 0 ]; do
+    name=$1
+    case "$name" in
+        -v|--version)
+            shift
+            MANIFEST_VERSION=$1
+            ;;
+        -d|--dotnet-install-dir)
+            shift
+            DOTNET_INSTALL_DIR=$1
+            ;;
+        -h|--help)
+            script_name="$(basename "$0")"
+            echo "Tizen Workload Installer"
+            echo "Usage: $script_name [-v|--version <VERSION>] [-d|--dotnet-install-dir <DIR>]"
+            echo "       $script_name -h|-?|--help"
+            echo ""
+            echo "Options:"
+            echo "  -v,--version <VERSION>         Use specific VERSION, Defaults to \`$MANIFEST_VERSION\`."
+            echo "  -d,--dotnet-install-dir <DIR>  Dotnet SDK Location installed, Defaults to \`$DOTNET_INSTALL_DIR\`."
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument \`$name\`"
+            exit 1
+            ;;
+    esac
+
+    shift
+done
+
+SDK_MANIFESTS_DIR=$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_VERSION_BAND
+
+echo "Installing $MANIFEST_NAME/$MANIFEST_VERSION to $SDK_MANIFESTS_DIR..."
+
+if [ ! -d $SDK_MANIFESTS_DIR ]; then
+    echo "No target directory \`$SDK_MANIFESTS_DIR\`";
+    exit 1
+fi
+
+if [ ! -w $SDK_MANIFESTS_DIR ]; then
+    echo "No permission to install manifest. Try again with sudo."
+    exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+
+# Download and extract the manifest nuget package.
+curl -s -o $TMPDIR/manifest.zip -L https://www.nuget.org/api/v2/package/$MANIFEST_NAME/$MANIFEST_VERSION
+unzip -qq -d $TMPDIR/unzipped $TMPDIR/manifest.zip
+if [ ! -d $TMPDIR/unzipped/data ]; then
+    echo "No such files to install."
+    exit 1
+fi
+chmod 744 $TMPDIR/unzipped/data/*
+
+# Copy manifest files to dotnet sdk.
+mkdir -p $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen
+cp -f $TMPDIR/unzipped/data/* $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/
+
+if [ ! -f $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/WorkloadManifest.json ]; then
+    echo "Installation is failed."
+    exit 1
+fi
+
+# Clean-up
+rm -fr $TMPDIR
+
+echo "Tizen manifest is installed to $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/."
+echo ""
+echo "Run \`dotnet workload install tizen\` to install tizen workload packs."

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -76,9 +76,8 @@ if [ ! -f $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/WorkloadManifest.json ]; then
     exit 1
 fi
 
+# Install workload packs.
+$DOTNET_INSTALL_DIR/dotnet workload install tizen --skip-manifest-update
+
 # Clean-up
 rm -fr $TMPDIR
-
-echo "Tizen manifest is installed to $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/."
-echo ""
-echo "Run \`dotnet workload install tizen --skip-manifest-update\` to install tizen workload packs."

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -81,4 +81,4 @@ rm -fr $TMPDIR
 
 echo "Tizen manifest is installed to $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/."
 echo ""
-echo "Run \`dotnet workload install tizen\` to install tizen workload packs."
+echo "Run \`dotnet workload install tizen --skip-manifest-update\` to install tizen workload packs."


### PR DESCRIPTION
This script installs the Tizen workload manifest files and packs to the dotnet sdk location.

### Usage
On Linux:
```
workload-install.sh [-v <Version>] [-d <Dotnet SDK Location>]
```

On Windows:
```
workload-install.ps1 [-v <Version>] [-d <Dotnet SDK Location>]
```

If this script is executed in CI environment, you can use `curl` to download the script and execute it.
```
curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | bash
```
or
```
curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | bash -s -- -v <version> -d <dotnet sdk location>
```
