### PR TITLE
Exclude assets written in PlatformManifests of Targeting pack always

### DIFF
--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
@@ -95,6 +95,19 @@ Copyright (c) Samsung All rights reserved.
 
   <!--
   ===========================================================================
+  _UsePlatformManifestsAlways
+
+  TPK must exclude the assets provided by platform.
+  ===========================================================================
+  -->
+  <Target Name="_UsePlatformManifestsAlways" DependsOnTargets="ResolveTargetingPackAssets" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <PackageConflictPlatformManifests Include="@(PlatformManifestsFromTargetingPacks)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+  ===========================================================================
   TizenPackage
 
   The tpk sign & package entry point.
@@ -354,7 +367,7 @@ Copyright (c) Samsung All rights reserved.
 
   </Target>
 
-    <!--
+  <!--
   ===========================================================================
   ClearReferenceCopyLocalPaths if SupportMultiAppPackage is set to false in csproj
   ===========================================================================


### PR DESCRIPTION
In case of reference a package using Tizen.NET 4.0.0, the tpk includes all runtime assets of the Tizen.NET package in self-contained build. To resolve this problem, the PackageConflictPlatformManifests is always set.