### PR TITLE
[scripts] Use DOTNET_ROOT at installation

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -17,7 +17,7 @@ Dotnet SDK Location installed
 [cmdletbinding()]
 param(
     [Alias('v')][string]$Version="<latest>",
-    [Alias('d')][string]$DotnetInstallDir="$env:Programfiles\dotnet"
+    [Alias('d')][string]$DotnetInstallDir="<auto>"
 )
 
 Set-StrictMode -Version Latest
@@ -57,10 +57,24 @@ function Get-Package([string]$Id, [string]$Version, [string]$Destination, [strin
     return $OutFilePath
 }
 
+# Check dotnet install directory.
+if ($DotnetInstallDir -eq "<auto>") {
+    if (Test-Path $Env:DOTNET_ROOT) {
+        $DotnetInstallDir = $Env:DOTNET_ROOT
+    } else {
+        $DotnetInstallDir = Join-Path -Path $Env:Programfiles -ChildPath "dotnet"
+    }
+}
+if (-Not $(Test-Path $DotnetInstallDir)) {
+    Write-Error "No installed dotnet '$DotnetInstallDir'."
+}
+
+# Check latest version of manifest.
 if ($Version -eq "<latest>") {
     $Version = Get-LatestVersion -Id $ManifestName
 }
 
+# Check workload manifest directory.
 $ManifestDir = Join-Path -Path $DotnetInstallDir -ChildPath "sdk-manifests" | Join-Path -ChildPath $DotnetVersionBand
 $TizenManifestDir = Join-Path -Path $ManifestDir -ChildPath "samsung.net.sdk.tizen"
 Test-Directory $ManifestDir

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -9,7 +9,7 @@ MANIFEST_NAME="samsung.net.sdk.tizen.manifest-6.0.100"
 MANIFEST_VERSION="<latest>"
 
 DOTNET_VERSION_BAND=6.0.100
-DOTNET_INSTALL_DIR=/usr/share/dotnet
+DOTNET_INSTALL_DIR="<auto>"
 
 while [ $# -ne 0 ]; do
     name=$1
@@ -42,6 +42,19 @@ while [ $# -ne 0 ]; do
     shift
 done
 
+# Check dotnet install directory.
+if [[ "$DOTNET_INSTALL_DIR" == "<auto>" ]]; then
+    if [[ -n "$DOTNET_ROOT" && -d "$DOTNET_ROOT" ]]; then
+        DOTNET_INSTALL_DIR=$DOTNET_ROOT
+    else
+        DOTNET_INSTALL_DIR="/usr/share/dotnet"
+    fi
+fi
+if [ ! -d $DOTNET_INSTALL_DIR ]; then
+    echo "No installed dotnet \`$DOTNET_INSTALL_DIR\`."
+    exit 1
+fi
+
 # Check latest version of manifest.
 if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then
     MANIFEST_VERSION=$(curl -s https://api.nuget.org/v3-flatcontainer/$MANIFEST_NAME/index.json | grep \" | tail -n 1 | tr -d '\r' | xargs)
@@ -51,10 +64,10 @@ if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then
     fi
 fi
 
+# Check workload manifest directory.
 SDK_MANIFESTS_DIR=$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_VERSION_BAND
-# Check target manifest directory.
 if [ ! -d $SDK_MANIFESTS_DIR ]; then
-    echo "No target directory \`$SDK_MANIFESTS_DIR\`";
+    echo "No target directory \`$SDK_MANIFESTS_DIR\`.";
     exit 1
 fi
 


### PR DESCRIPTION
If `DOTNET_ROOT` environment variable exists and the dotnet installation directory is not set by using `-d` option, 
The installation script will try to install the workload to `DOTNET_ROOT` path first.