### PR TITLE
Make sure paths are not null

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -34,7 +34,7 @@ function New-TemporaryDirectory {
 }
 
 function Test-Directory([string]$TestDir) {
-    if (-Not $(Test-Path $TestDir)) {
+    if (-Not $(Test-Path "$TestDir")) {
         Write-Error "No target directory '$TestDir'."
     }
     Try {
@@ -59,13 +59,13 @@ function Get-Package([string]$Id, [string]$Version, [string]$Destination, [strin
 
 # Check dotnet install directory.
 if ($DotnetInstallDir -eq "<auto>") {
-    if (Test-Path $Env:DOTNET_ROOT) {
+    if (Test-Path "$Env:DOTNET_ROOT") {
         $DotnetInstallDir = $Env:DOTNET_ROOT
     } else {
         $DotnetInstallDir = Join-Path -Path $Env:Programfiles -ChildPath "dotnet"
     }
 }
-if (-Not $(Test-Path $DotnetInstallDir)) {
+if (-Not $(Test-Path "$DotnetInstallDir")) {
     Write-Error "No installed dotnet '$DotnetInstallDir'."
 }
 


### PR DESCRIPTION
Without quotes, empty envvars will throw:

```
> .\workload-install.ps1
Test-Path: C:\Projects\Maui\workload-install.ps1:62
Line |
  62 |      if (Test-Path $Env:DOTNET_ROOT) {
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Value cannot be null. (Parameter 'The provided Path argument was null or an empty collection.')
```