### PR TITLE
Bump dotnet sdk to 6.0.100-rc.1.21458.32

### DIFF
--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-rc.1.21427.28</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>6.0.100-rc.1.21458.32</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>6.0.0-beta.21212.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
- Bump dotnet sdk to 6.0.100-rc.1.21458.32