### PR TITLE
Create template-packs directory if not exists

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -74,8 +74,10 @@ function Install-Pack([string]$Id, [string]$Version, [string]$Kind) {
             Copy-Item -Path "$TempUnzipDir/*" -Destination $TargetDirectory -Recurse -Force
         }
         "template" {
-            $TargetFileName = "$Id.$Version.nupkg".ToLower();
-            Copy-Item $TempZipFile -Destination $(Join-Path -Path $DotnetInstallDir -ChildPath "template-packs\$TargetFileName") -Force
+            $TargetFileName = "$Id.$Version.nupkg".ToLower()
+            $TargetDirectory = $(Join-Path -Path $DotnetInstallDir -ChildPath "template-packs")
+            New-Item -Path $TargetDirectory -ItemType "directory" -Force | Out-Null
+            Copy-Item $TempZipFile -Destination $(Join-Path -Path $TargetDirectory -ChildPath "$TargetFileName") -Force
         }
     }
 }


### PR DESCRIPTION
- Fix `workload-install.ps1` to create `template-packs` directory if not exists.