### PR TITLE
Support legacy TFM in condition

### DIFF
--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.After.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.After.targets
@@ -17,7 +17,7 @@ Copyright (c) Samsung All rights reserved.
   </PropertyGroup>
 
   <Import Project="Samsung.Tizen.Sdk.Common.targets" />
-  <Import Project="Samsung.Tizen.Sdk.NuGet.targets" />
+  <Import Project="Samsung.Tizen.Sdk.NuGet.targets" Condition=" '$(MSBuildRuntimeType)' == 'Full' and '$(MSBuildVersion)' &lt; '17.0' " />
   <Import Project="Samsung.Tizen.Sdk.Packaging.targets" />
   <Import Project="Samsung.Tizen.Sdk.Applications.targets" Condition="'$(OutputType)'=='Exe'" />
   <Import Project="Samsung.Tizen.Sdk.VisualStudio.targets" />


### PR DESCRIPTION
### Summary ###
Nuget workaround `Samsung.Tizen.Sdk.NuGet.targets` for supporting legacy TFM should be removed, since we now have dotnet/installer with `net6.0-tizen` precedence support.
However, this is still required when we want Visual Studio 2019 on Windows to continue working for .NET6 projects.