### PR TITLE
Fix Samsung.Tizen.Sdk.Packaging.targets

### DIFF
--- a/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
+++ b/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
@@ -17,13 +17,8 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <TizenManifestFile Condition="'$(TizenManifestFile)'==''">tizen-manifest.xml</TizenManifestFile>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(EnableDefaultTizenItems)' == 'true'">
     <TizenResource Include="res\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
-    <TizenLibrary Include="lib\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
     <TizenSharedResource Include="shared\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
   </ItemGroup>
 

--- a/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
+++ b/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
@@ -17,6 +17,16 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <TizenManifestFile Condition="'$(TizenManifestFile)' == ''">tizen-manifest.xml</TizenManifestFile>
+    <TizenResourcePrefix Condition="'$(TizenResourcePrefix)' == ''">res</TizenResourcePrefix>
+    <TizenSharedPrefix Condition="'$(TizenSharedPrefix)' == ''">shared</TizenSharedPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TizenLibrary Include="lib\**\*" Exclude="@(TizenTpkUserExcludeFiles)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(EnableDefaultTizenItems)' == 'true'">
     <TizenResource Include="$(TizenResourcePrefix)\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
     <TizenSharedResource Include="$(TizenSharedPrefix)\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />

--- a/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
+++ b/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
@@ -18,8 +18,8 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup Condition="'$(EnableDefaultTizenItems)' == 'true'">
-    <TizenResource Include="$(TizenProjectFolder)res\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
-    <TizenSharedResource Include="$(TizenProjectFolder)shared\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
+    <TizenResource Include="$(TizenResourcePrefix)\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
+    <TizenSharedResource Include="$(TizenSharedPrefix)\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
   </ItemGroup>
 
 </Project>

--- a/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
+++ b/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
@@ -18,8 +18,8 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup Condition="'$(EnableDefaultTizenItems)' == 'true'">
-    <TizenResource Include="res\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
-    <TizenSharedResource Include="shared\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
+    <TizenResource Include="$(TizenProjectFolder)res\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
+    <TizenSharedResource Include="$(TizenProjectFolder)shared\**\*" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(TizenTpkUserExcludeFiles)" />
   </ItemGroup>
 
 </Project>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
@@ -34,10 +34,6 @@ Copyright (c) Samsung All rights reserved.
   </ItemDefinitionGroup>
 
   <PropertyGroup>
-    <TizenManifestFile Condition="'$(TizenManifestFile)'==''">tizen-manifest.xml</TizenManifestFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TpkKeepMeta>
       TizenTpkFileName;
       TizenTpkSubDir;
@@ -251,14 +247,11 @@ Copyright (c) Samsung All rights reserved.
 
     <!-- Default Resource File Include from Project -->
     <ItemGroup>
-      <DefaultTpkLibFiles Include="lib\**\*" Exclude="@(TizenTpkUserExcludeFiles)" />
-      <DefaultTpkManifestFiles Include="$(TizenManifestFile)" />
-
-      <TizenTpkFiles Include="@(DefaultTpkLibFiles)" Condition="Exists('%(DefaultTpkLibFiles.Identity)')">
-        <TizenTpkSubDir>lib\%(DefaultTpkLibFiles.RecursiveDir)</TizenTpkSubDir>
+      <TizenTpkFiles Include="@(TizenLibrary)" Condition="Exists('%(TizenLibrary.Identity)')">
+        <TizenTpkSubDir>lib\%(TizenLibrary.RecursiveDir)</TizenTpkSubDir>
         <TizenTpkFileName>%(Filename)%(Extension)</TizenTpkFileName>
       </TizenTpkFiles>
-      <TizenTpkFiles Include="@(DefaultTpkManifestFiles)" Condition="Exists('%(DefaultTpkManifestFiles.Identity)')">
+      <TizenTpkFiles Include="$(TizenManifestFile)" Condition="Exists('$(TizenManifestFile)')">
         <TizenTpkFileName>%(Filename)%(Extension)</TizenTpkFileName>
         <TizenTpkIsManifest>true</TizenTpkIsManifest>
         <TizenTpkIsBaseManifest>true</TizenTpkIsBaseManifest>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
@@ -245,24 +245,35 @@ Copyright (c) Samsung All rights reserved.
       <_TizenProjectFiles Remove ="@(_TizenProjectFiles)" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <EnableDefaultTpkItems Condition=" '$(EnableDefaultTpkItems)' == '' ">true</EnableDefaultTpkItems>
+    </PropertyGroup>
+
     <!-- Default Resource File Include from Project -->
-    <ItemGroup Condition=" '$(EnableDefaultTizenItems)' == 'true' ">
-      <TizenTpkFiles Include="@(TizenResource)" Condition="Exists('%(TizenResource.Identity)')">
-        <TizenTpkSubDir>res\%(TizenResource.RecursiveDir)</TizenTpkSubDir>
+    <ItemGroup Condition=" '$(EnableDefaultTpkItems)' == 'true' ">
+      <DefaultTpkLibFiles Include="lib\**\*" Exclude="@(TizenTpkUserExcludeFiles)" />
+      <DefaultTpkManifestFiles Include="$(TizenManifestFile)" />
+
+      <TizenTpkFiles Include="@(DefaultTpkLibFiles)" Condition="Exists('%(DefaultTpkLibFiles.Identity)')">
+        <TizenTpkSubDir>lib\%(DefaultTpkLibFiles.RecursiveDir)</TizenTpkSubDir>
         <TizenTpkFileName>%(Filename)%(Extension)</TizenTpkFileName>
       </TizenTpkFiles>
-      <TizenTpkFiles Include="@(TizenLibrary)" Condition="Exists('%(TizenLibrary.Identity)')">
-        <TizenTpkSubDir>lib\%(TizenLibrary.RecursiveDir)</TizenTpkSubDir>
+      <TizenTpkFiles Include="@(DefaultTpkManifestFiles)" Condition="Exists('%(DefaultTpkManifestFiles.Identity)')">
         <TizenTpkFileName>%(Filename)%(Extension)</TizenTpkFileName>
+        <TizenTpkIsManifest>true</TizenTpkIsManifest>
+        <TizenTpkIsBaseManifest>true</TizenTpkIsBaseManifest>
+      </TizenTpkFiles>
+    </ItemGroup>
+
+    <!-- Include Files -->
+    <ItemGroup>
+      <TizenTpkFiles Include="@(TizenResource)" Condition="Exists('%(TizenResource.Identity)')">
+        <TizenTpkSubDir>res\%(TizenResource.RecursiveDir)</TizenTpkSubDir>
+        <TizenTpkFileName Condition="'%(TizenResource.TizenTpkFileName)' == ''">%(Filename)%(Extension)</TizenTpkFileName>
       </TizenTpkFiles>
       <TizenTpkFiles Include="@(TizenSharedResource)" Condition="Exists('%(TizenSharedResource.Identity)')">
         <TizenTpkSubDir>shared\%(TizenSharedResource.RecursiveDir)</TizenTpkSubDir>
         <TizenTpkFileName>%(Filename)%(Extension)</TizenTpkFileName>
-      </TizenTpkFiles>
-      <TizenTpkFiles Include="$(TizenManifestFile)" Condition="Exists('$(TizenManifestFile)')">
-        <TizenTpkFileName>%(Filename)%(Extension)</TizenTpkFileName>
-        <TizenTpkIsManifest>true</TizenTpkIsManifest>
-        <TizenTpkIsBaseManifest>true</TizenTpkIsBaseManifest>
       </TizenTpkFiles>
       <TizenTpkFiles Include="@(TizenTpkUserIncludeFiles)" Exclude="@(TizenTpkUserExcludeFiles)">
         <TizenTpkSubDir Condition="'%(TizenTpkUserIncludeFiles.TizenTpkSubDir)' == ''">%(TizenTpkUserIncludeFiles.RelativeDir)</TizenTpkSubDir>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
@@ -249,12 +249,8 @@ Copyright (c) Samsung All rights reserved.
       <_TizenProjectFiles Remove ="@(_TizenProjectFiles)" />
     </ItemGroup>
 
-    <PropertyGroup>
-      <EnableDefaultTpkItems Condition=" '$(EnableDefaultTpkItems)' == '' ">true</EnableDefaultTpkItems>
-    </PropertyGroup>
-
     <!-- Default Resource File Include from Project -->
-    <ItemGroup Condition=" '$(EnableDefaultTpkItems)' == 'true' ">
+    <ItemGroup>
       <DefaultTpkLibFiles Include="lib\**\*" Exclude="@(TizenTpkUserExcludeFiles)" />
       <DefaultTpkManifestFiles Include="$(TizenManifestFile)" />
 

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Packaging.targets
@@ -34,6 +34,10 @@ Copyright (c) Samsung All rights reserved.
   </ItemDefinitionGroup>
 
   <PropertyGroup>
+    <TizenManifestFile Condition="'$(TizenManifestFile)'==''">tizen-manifest.xml</TizenManifestFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <TpkKeepMeta>
       TizenTpkFileName;
       TizenTpkSubDir;


### PR DESCRIPTION
### Summary
This PR fixes` Samsung.Tizen.Sdk.Packaging.targets` to include essential items when packaging Tizen tpk.

### Problem
- Maui Tizen application now excludes all assets when the `EnableDefaultTizenItems` option is set to `false`.
  - The default value of `EnableDefaultTizenItems`  for Maui Singleproject is `false`.
  - The purpose of MAUI is to manage MAUI assets by itself.

### Solve
- Take following Tizen items out of `EnableDefaultTizenItems` option block, and add them as default items.
  - `tizen-manifest.xml` : essential item.
  - `lib/` : This is not managed by Maui.
- Always Include followings. Default items will also be added to followings when option is on.
  - @(TizenResource)
  - @(TizenSharedResource)
  - @(TizenTpkUserIncludeFiles)