### PR TITLE
Update workload install scripts

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -24,8 +24,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-$ManifestName = "Samsung.NET.Sdk.Tizen.Manifest-6.0.200"
-$DotnetVersionBand = "6.0.200"
+$ManifestBaseName = "Samsung.NET.Sdk.Tizen.Manifest"
 
 function New-TemporaryDirectory {
     $parent = [System.IO.Path]::GetTempPath()
@@ -46,7 +45,11 @@ function Test-Directory([string]$TestDir) {
 }
 
 function Get-LatestVersion([string]$Id) {
-    $Response = Invoke-WebRequest -Uri https://api.nuget.org/v3-flatcontainer/$Id/index.json | ConvertFrom-Json
+    try {
+        $Response = Invoke-WebRequest -Uri https://api.nuget.org/v3-flatcontainer/$Id/index.json | ConvertFrom-Json
+    } catch {
+        Write-Error "Wrong Id: $Id"
+    }
     return $Response.versions | Select-Object -Last 1
 }
 
@@ -108,6 +111,21 @@ if ($DotnetInstallDir -eq "<auto>") {
 }
 if (-Not $(Test-Path "$DotnetInstallDir")) {
     Write-Error "No installed dotnet '$DotnetInstallDir'."
+}
+
+# Check installed dotnet version
+$DotnetCommand = "$DotnetInstallDir\dotnet"
+if (Get-Command $DotnetCommand -ErrorAction SilentlyContinue)
+{
+    $DotnetVersion = Invoke-Expression "& '$DotnetCommand' --version"
+    $VersionSplitSymbol = '.'
+    $SplitVersion = $DotnetVersion.Split($VersionSplitSymbol);
+    $DotnetVersionBand = $SplitVersion[0] + $VersionSplitSymbol + $SplitVersion[1] + $VersionSplitSymbol + $SplitVersion[2][0] + "00"
+    $ManifestName = "$ManifestBaseName-$DotnetVersionBand"
+}
+else
+{
+    Write-Error "'$DotnetCommand' occurs an error."
 }
 
 # Check latest version of manifest.

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -25,6 +25,7 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 $ManifestBaseName = "Samsung.NET.Sdk.Tizen.Manifest"
+$SupportedDotnetVersion = "6"
 
 function New-TemporaryDirectory {
     $parent = [System.IO.Path]::GetTempPath()
@@ -120,6 +121,11 @@ if (Get-Command $DotnetCommand -ErrorAction SilentlyContinue)
     $DotnetVersion = Invoke-Expression "& '$DotnetCommand' --version"
     $VersionSplitSymbol = '.'
     $SplitVersion = $DotnetVersion.Split($VersionSplitSymbol);
+    if ($SplitVersion[0] -ne $SupportedDotnetVersion)
+    {
+        Write-Host "Current .NET version is $DotnetVersion. .NET 6.0 SDK is required."
+        Exit 0
+    }
     $DotnetVersionBand = $SplitVersion[0] + $VersionSplitSymbol + $SplitVersion[1] + $VersionSplitSymbol + $SplitVersion[2][0] + "00"
     $ManifestName = "$ManifestBaseName-$DotnetVersionBand"
 }

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -57,7 +57,7 @@ fi
 # Check installed dotnet version
 DOTNET_COMMAND="$DOTNET_INSTALL_DIR/dotnet"
 
-if ! type "$DOTNET_COMMAND" > /dev/null; then
+if [ ! -x "$DOTNET_COMMAND" ]; then
     echo "$DOTNET_COMMAND command not found"
     exit 1
 fi

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -5,10 +5,8 @@
 
 #!/bin/bash -e
 
-MANIFEST_NAME="samsung.net.sdk.tizen.manifest-6.0.200"
+MANIFEST_BASE_NAME="samsung.net.sdk.tizen.manifest"
 MANIFEST_VERSION="<latest>"
-
-DOTNET_VERSION_BAND=6.0.200
 DOTNET_INSTALL_DIR="<auto>"
 
 while [ $# -ne 0 ]; do
@@ -54,6 +52,19 @@ if [ ! -d $DOTNET_INSTALL_DIR ]; then
     echo "No installed dotnet \`$DOTNET_INSTALL_DIR\`."
     exit 1
 fi
+
+# Check installed dotnet version
+DOTNET_COMMAND="$DOTNET_INSTALL_DIR/dotnet"
+
+if ! type "$DOTNET_COMMAND" > /dev/null; then
+    echo "$DOTNET_COMMAND command not found"
+    exit 1
+fi
+
+DOTNET_VERSION=$($DOTNET_COMMAND --version)
+IFS='.' read -r -a array <<< "$DOTNET_VERSION"
+DOTNET_VERSION_BAND="${array[0]}.${array[1]}.${array[2]:0:1}00"
+MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_VERSION_BAND"
 
 # Check latest version of manifest.
 if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -6,6 +6,7 @@
 #!/bin/bash -e
 
 MANIFEST_BASE_NAME="samsung.net.sdk.tizen.manifest"
+SupportedDotnetVersion="6"
 MANIFEST_VERSION="<latest>"
 DOTNET_INSTALL_DIR="<auto>"
 
@@ -63,6 +64,11 @@ fi
 
 DOTNET_VERSION=$($DOTNET_COMMAND --version)
 IFS='.' read -r -a array <<< "$DOTNET_VERSION"
+if [[ ${array[0]} != $SupportedDotnetVersion ]]; then
+    echo "Current .NET version is ${DOTNET_VERSION}. .NET 6.0 SDK is required."
+    exit 0
+fi
+
 DOTNET_VERSION_BAND="${array[0]}.${array[1]}.${array[2]:0:1}00"
 MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_VERSION_BAND"
 


### PR DESCRIPTION
### Summary 
Update Tizen workload install scripts to get `.NET SDK version band` based on installed dotnet.
Updated scripts will
   - use installed `dotnet` on given or default path to get version
   - reformat the version to version band (ex: `6.0.100` `6.0.200`)
   - use version band to download Tizen manifest and install workload
   - Exit quietly when local dotnet version is not .NET 6.