### PR TITLE
Add dotnet installation path candidates

### DIFF
--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -63,7 +63,7 @@ if [[ "$DOTNET_INSTALL_DIR" == "<auto>" ]]; then
         DOTNET_INSTALL_DIR=$DOTNET_DEFAULT_PATH_LINUX
     elif [[ -d "$DOTNET_DEFAULT_PATH_MACOS" ]]; then
         DOTNET_INSTALL_DIR=$DOTNET_DEFAULT_PATH_MACOS
-    else
+    elif [[ -n "$(which dotnet)" ]]; then
         DOTNET_INSTALL_DIR=$(read_dotnet_link $(which dotnet))
     fi
 fi

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -9,6 +9,8 @@ MANIFEST_BASE_NAME="samsung.net.sdk.tizen.manifest"
 SupportedDotnetVersion="6"
 MANIFEST_VERSION="<latest>"
 DOTNET_INSTALL_DIR="<auto>"
+DOTNET_DEFAULT_PATH_LINUX="/usr/share/dotnet"
+DOTNET_DEFAULT_PATH_MACOS="/usr/local/share/dotnet"
 
 while [ $# -ne 0 ]; do
     name=$1
@@ -41,12 +43,28 @@ while [ $# -ne 0 ]; do
     shift
 done
 
+function read_dotnet_link() {
+    cd -P "$(dirname "$1")"
+    dotnet_file="$PWD/$(basename "$1")"
+    while [[ -h "$dotnet_file" ]]; do
+        cd -P "$(dirname "$dotnet_file")"
+        dotnet_file="$(readlink "$dotnet_file")"
+        cd -P "$(dirname "$dotnet_file")"
+        dotnet_file="$PWD/$(basename "$dotnet_file")"
+    done
+    echo $PWD
+}
+
 # Check dotnet install directory.
 if [[ "$DOTNET_INSTALL_DIR" == "<auto>" ]]; then
     if [[ -n "$DOTNET_ROOT" && -d "$DOTNET_ROOT" ]]; then
         DOTNET_INSTALL_DIR=$DOTNET_ROOT
+    elif [[ -d "$DOTNET_DEFAULT_PATH_LINUX" ]]; then
+        DOTNET_INSTALL_DIR=$DOTNET_DEFAULT_PATH_LINUX
+    elif [[ -d "$DOTNET_DEFAULT_PATH_MACOS" ]]; then
+        DOTNET_INSTALL_DIR=$DOTNET_DEFAULT_PATH_MACOS
     else
-        DOTNET_INSTALL_DIR="/usr/share/dotnet"
+        DOTNET_INSTALL_DIR=$(read_dotnet_link $(which dotnet))
     fi
 fi
 if [ ! -d $DOTNET_INSTALL_DIR ]; then


### PR DESCRIPTION
## Summary
This PR update the logic to find an installed dotnet path.

### Steps to find dotnet
1.  Check `DOTNET_ROOT` environement path
2.  Check a default dotnet path for linux `/usr/share/dotnet`.
3.  Check a default dotnet path for macos `/usr/local/share/dotnet`.
4.  Check dotnet link path on a machine.
