### PR TITLE
Add install option: target version band

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -17,7 +17,8 @@ Dotnet SDK Location installed
 [cmdletbinding()]
 param(
     [Alias('v')][string]$Version="<latest>",
-    [Alias('d')][string]$DotnetInstallDir="<auto>"
+    [Alias('d')][string]$DotnetInstallDir="<auto>",
+    [Alias('t')][string]$DotnetTargetVersionBand="<auto>"
 )
 
 Set-StrictMode -Version Latest
@@ -134,13 +135,17 @@ else
     Write-Error "'$DotnetCommand' occurs an error."
 }
 
+if ($DotnetTargetVersionBand -eq "<auto>") {
+    $DotnetTargetVersionBand = $DotnetVersionBand
+}
+
 # Check latest version of manifest.
 if ($Version -eq "<latest>") {
     $Version = Get-LatestVersion -Id $ManifestName
 }
 
 # Check workload manifest directory.
-$ManifestDir = Join-Path -Path $DotnetInstallDir -ChildPath "sdk-manifests" | Join-Path -ChildPath $DotnetVersionBand
+$ManifestDir = Join-Path -Path $DotnetInstallDir -ChildPath "sdk-manifests" | Join-Path -ChildPath $DotnetTargetVersionBand
 $TizenManifestDir = Join-Path -Path $ManifestDir -ChildPath "samsung.net.sdk.tizen"
 $TizenManifestFile = Join-Path -Path $TizenManifestDir -ChildPath "WorkloadManifest.json"
 Test-Directory $ManifestDir
@@ -176,9 +181,9 @@ $NewManifestJson.packs.PSObject.Properties | ForEach-Object {
 }
 
 # Add tizen to the installed workload metadata.
-New-Item -Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstalledWorkloads\tizen") -Force | Out-Null
-if (Test-Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstallerType\msi")) {
-    New-Item -Path "HKLM:\SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\x64\$DotnetVersionBand\tizen" -Force | Out-Null
+New-Item -Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetTargetVersionBand\InstalledWorkloads\tizen") -Force | Out-Null
+if (Test-Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetTargetVersionBand\InstallerType\msi")) {
+    New-Item -Path "HKLM:\SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\x64\$DotnetTargetVersionBand\tizen" -Force | Out-Null
 }
 
 # Clean up

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -9,6 +9,7 @@ MANIFEST_BASE_NAME="samsung.net.sdk.tizen.manifest"
 SupportedDotnetVersion="6"
 MANIFEST_VERSION="<latest>"
 DOTNET_INSTALL_DIR="<auto>"
+DOTNET_TARGET_VERSION_BAND="<auto>"
 DOTNET_DEFAULT_PATH_LINUX="/usr/share/dotnet"
 DOTNET_DEFAULT_PATH_MACOS="/usr/local/share/dotnet"
 
@@ -23,15 +24,20 @@ while [ $# -ne 0 ]; do
             shift
             DOTNET_INSTALL_DIR=$1
             ;;
+        -t|--dotnet-target-version-band)
+            shift
+            DOTNET_TARGET_VERSION_BAND=$1
+            ;;
         -h|--help)
             script_name="$(basename "$0")"
             echo "Tizen Workload Installer"
-            echo "Usage: $script_name [-v|--version <VERSION>] [-d|--dotnet-install-dir <DIR>]"
+            echo "Usage: $script_name [-v|--version <VERSION>] [-d|--dotnet-install-dir <DIR>] [-t|--dotnet-target-version-band <VERSION>]"
             echo "       $script_name -h|-?|--help"
             echo ""
             echo "Options:"
-            echo "  -v,--version <VERSION>         Use specific VERSION, Defaults to \`$MANIFEST_VERSION\`."
-            echo "  -d,--dotnet-install-dir <DIR>  Dotnet SDK Location installed, Defaults to \`$DOTNET_INSTALL_DIR\`."
+            echo "  -v,--version <VERSION>                     Use specific VERSION, Defaults to \`$MANIFEST_VERSION\`."
+            echo "  -d,--dotnet-install-dir <DIR>              Dotnet SDK Location installed, Defaults to \`$DOTNET_INSTALL_DIR\`."
+            echo "  -t,--dotnet-target-version-band <VERSION>  Use specific dotnet version band for install location, Defaults to \`$DOTNET_TARGET_VERSION_BAND\`."
             exit 0
             ;;
         *)
@@ -90,6 +96,12 @@ fi
 DOTNET_VERSION_BAND="${array[0]}.${array[1]}.${array[2]:0:1}00"
 MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_VERSION_BAND"
 
+
+if [[ "$DOTNET_TARGET_VERSION_BAND" == "<auto>" ]]; then
+    DOTNET_TARGET_VERSION_BAND=$DOTNET_VERSION_BAND
+fi
+
+
 # Check latest version of manifest.
 if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then
     MANIFEST_VERSION=$(curl -s https://api.nuget.org/v3-flatcontainer/$MANIFEST_NAME/index.json | grep \" | tail -n 1 | tr -d '\r' | xargs)
@@ -100,7 +112,7 @@ if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then
 fi
 
 # Check workload manifest directory.
-SDK_MANIFESTS_DIR=$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_VERSION_BAND
+SDK_MANIFESTS_DIR=$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_TARGET_VERSION_BAND
 if [ ! -d $SDK_MANIFESTS_DIR ]; then
     echo "No target directory \`$SDK_MANIFESTS_DIR\`.";
     exit 1


### PR DESCRIPTION
## Summary
Add a new option '-t'  for Tizen workload installation.
`-t` option is used to modify an install path for a specified dotnet version band folder. 
Default behavior without `-t` option is to install workload in a corresponding dotnet version band folder.

For example, you can install a workload(`7.0.100-preview.6.19`) belonging to dotnet version band `6.0.200` to  `6.0.300` folder.
```sh
~$ ./workload-install.ps1 -v 7.0.100-preview.6.19 -t 6.0.300
```
The workload version (`7.0.100-preview.6.19`) still should be one in the installed dotnet version band on a local machine.

## Purpose of New Option
The purpose of providing a new option is to test and verify MAUI on a next version of dotnet version band.