### PR TITLE
product name spelling and grammar corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Tizen .NET is :
   * Linux / Windows / macOS : https://dotnet.microsoft.com/download/dotnet/6.0
   
 **- Visual Studio 2022**
-  * To create Tizen .NET with .NET6, you need the latest version of [Visual Studio 2022](https://visualstudio.microsoft.com/)
+  * To create Tizen .NET with .NET 6, you need the latest version of [Visual Studio 2022](https://visualstudio.microsoft.com/)
 
 ### Installing Tizen workload for .NET 6.0 (Preview)
   You can install Tizen workload for .NET 6.0 by using the installer script.
-  * On Linux/MacOS:
+  * On Linux / macOS:
   ```sh
   curl -sSL https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.sh | sudo bash
   ```
@@ -141,4 +141,4 @@ Unfortunately `dotnet run` is not yet integrated. So for now you need to use `sd
 sdb install bin/Debug/net6.0-tizen/com.companyname.HelloTizenNet6-1.0.0.tpk
 ```
 
-> Tizen emulators and devices that support .NET6 have not yet been officially released, and we will announce a binary for testing soon.
+> Tizen emulators and devices that support .NET 6 have not yet been officially released, and we will announce a binary for testing soon.

--- a/workload/scripts/README.md
+++ b/workload/scripts/README.md
@@ -5,7 +5,7 @@
 This script installs the Tizen workload manifest files and packs to the installed dotnet sdk.
 
 ### Usage
-On Linux/MacOS:
+On Linux / macOS:
 ```
 workload-install.sh [-v <Version>] [-d <Dotnet SDK Location>] [-t <Dotnet Version Band Target Folder>]
 ```


### PR DESCRIPTION
including .NET6 -> .NET 6, MacOS -> macOS, Linux/MacOS -> Linux / macOS