### PR TITLE
Add property to mark if Tizen workload is installed

### DIFF
--- a/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
+++ b/workload/src/Samsung.Tizen.Sdk/Sdk/AutoImport.props
@@ -18,6 +18,7 @@ https://github.com/dotnet/designs/blob/4703666296f5e59964961464c25807c727282cae/
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <TizenWorkloadInstalled Condition="'$(TizenWorkloadInstalled)' == ''">true</TizenWorkloadInstalled>
     <TizenManifestFile Condition="'$(TizenManifestFile)' == ''">tizen-manifest.xml</TizenManifestFile>
     <TizenResourcePrefix Condition="'$(TizenResourcePrefix)' == ''">res</TizenResourcePrefix>
     <TizenSharedPrefix Condition="'$(TizenSharedPrefix)' == ''">shared</TizenSharedPrefix>


### PR DESCRIPTION
### Summary
Add property `TizenWorkloadInstalled` to mark if Tizen workload is installed.
This property can be used at `dotnet/maui` to find out if Tizen workload is installed on a machine.
