### PR TITLE
[NET 7.0] Apply featured version band

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -162,9 +162,15 @@ else
 }
 
 if ($DotnetTargetVersionBand -eq "<auto>") {
-    $IsPreviewVersion = $DotnetVersion.Contains("-preview") -or $DotnetVersion.Contains("-rc") -or $DotnetVersion.Contains("-alpha")
-    if ($IsPreviewVersion -and ($SplitVersion.Count -ge 4)) {
-        $DotnetTargetVersionBand = $DotnetVersionBand + $SplitVersion[2].SubString(3) + $VersionSplitSymbol + $($SplitVersion[3])
+    if ($CurrentDotnetVersion -ge "7.0")
+    {
+        $IsPreviewVersion = $DotnetVersion.Contains("-preview") -or $DotnetVersion.Contains("-rc") -or $DotnetVersion.Contains("-alpha")
+        if ($IsPreviewVersion -and ($SplitVersion.Count -ge 4)) {
+            $DotnetTargetVersionBand = $DotnetVersionBand + $SplitVersion[2].SubString(3) + $VersionSplitSymbol + $($SplitVersion[3])
+        }
+        else {
+            $DotnetTargetVersionBand = $DotnetVersionBand
+        }
     }
     else {
         $DotnetTargetVersionBand = $DotnetVersionBand

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -162,7 +162,13 @@ else
 }
 
 if ($DotnetTargetVersionBand -eq "<auto>") {
-    $DotnetTargetVersionBand = $DotnetVersionBand
+    $IsPreviewVersion = $DotnetVersion.Contains("-preview") -or $DotnetVersion.Contains("-rc") -or $DotnetVersion.Contains("-alpha")
+    if ($IsPreviewVersion -and ($SplitVersion.Count -ge 4)) {
+        $DotnetTargetVersionBand = $DotnetVersionBand + $SplitVersion[2].SubString(3) + $VersionSplitSymbol + $($SplitVersion[3])
+    }
+    else {
+        $DotnetTargetVersionBand = $DotnetVersionBand
+    }
 }
 
 # Check latest version of manifest.

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -111,8 +111,12 @@ DOTNET_VERSION_BAND="${array[0]}.${array[1]}.${array[2]:0:1}00"
 MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_VERSION_BAND"
 
 if [[ "$DOTNET_TARGET_VERSION_BAND" == "<auto>" ]]; then
-    if [[ "$DOTNET_VERSION" == *"-preview"* || $DOTNET_VERSION == *"-rc"* || $DOTNET_VERSION == *"-alpha"* ]] && [[ ${#array[@]} -ge 4 ]]; then
-        DOTNET_TARGET_VERSION_BAND="$DOTNET_VERSION_BAND${array[2]:3}.${array[3]}"
+    if [[ "$CURRENT_DOTNET_VERSION" -ge "7" ]]; then
+        if [[ "$DOTNET_VERSION" == *"-preview"* || $DOTNET_VERSION == *"-rc"* || $DOTNET_VERSION == *"-alpha"* ]] && [[ ${#array[@]} -ge 4 ]]; then
+            DOTNET_TARGET_VERSION_BAND="$DOTNET_VERSION_BAND${array[2]:3}.${array[3]}"
+        else
+            DOTNET_TARGET_VERSION_BAND=$DOTNET_VERSION_BAND
+        fi
     else
         DOTNET_TARGET_VERSION_BAND=$DOTNET_VERSION_BAND
     fi

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -111,7 +111,11 @@ DOTNET_VERSION_BAND="${array[0]}.${array[1]}.${array[2]:0:1}00"
 MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_VERSION_BAND"
 
 if [[ "$DOTNET_TARGET_VERSION_BAND" == "<auto>" ]]; then
-    DOTNET_TARGET_VERSION_BAND=$DOTNET_VERSION_BAND
+    if [[ "$DOTNET_VERSION" == *"-preview"* || $DOTNET_VERSION == *"-rc"* || $DOTNET_VERSION == *"-alpha"* ]] && [[ ${#array[@]} -ge 4 ]]; then
+        DOTNET_TARGET_VERSION_BAND="$DOTNET_VERSION_BAND${array[2]:3}.${array[3]}"
+    else
+        DOTNET_TARGET_VERSION_BAND=$DOTNET_VERSION_BAND
+    fi
 fi
 
 LatestVersionMap=(


### PR DESCRIPTION
## Summary

Applying [.NET SDK Workload Preview Bands policy](https://github.com/dotnet/sdk/blob/main/documentation/general/workloads/workload-preview-bands.md) updated from Net 7.0. This PR changes dotnet target version band directory which is located under `dotnet/sdk-manifests/[target version band]`.

> Because of this, in .NET 7 we are changing the definition of the SDK band to include the first two components of the SDK version prerelease specifier, if present. So the SDK band for 7.0.100-preview.1.12345 would be 7.0.100-preview.1, and the SDK band for 7.0.100-rc.2.21505.57 would be 7.0.100-rc.2.

Dotnet featured version band for preview version is now include the first two components of SDK version like below.
```
"6.0.100" -> "6.0.100"
"10.0.512" -> "10.0.500"
"7.0.100-preview.1.12345" -> "7.0.100-preview.1"
"7.0.100-dev" -> "7.0.100"
"7.0.100-ci" -> "7.0.100"
"6.0.100-rc.2.21505.57" -> "6.0.100-rc.2"
"7.0.100-alpha.1.21558.2" -> "7.0.100-alpha.1"
```