### PR TITLE
Update Hotfix to formal code

### DIFF
--- a/workload/build/Samsung.NET.Sdk.Tizen.proj
+++ b/workload/build/Samsung.NET.Sdk.Tizen.proj
@@ -9,8 +9,18 @@ workload manifest pack containing information about the Tizen .NET workload.
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <!-- Hotfix for net7.0 version band to release -->
-    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">7.0.100-preview.6</DotNetPreviewVersionBand>
+    <!-- Trim all characters after first `-` or `+` is encountered. -->
+    <DotNetPreviewVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace($(MicrosoftDotnetSdkInternalPackageVersion), `[-+].*$`, ""))</DotNetPreviewVersionBand>
+  </PropertyGroup>
+
+  <!-- Apply featured version band for net 7.0 or above -->
+  <PropertyGroup Condition=" '$(DotNetPreviewVersionBand.StartsWith(6))' == 'False' ">
+    <IsPreview Condition="$(MicrosoftDotnetSdkInternalPackageVersion.Contains('-preview'))">True</IsPreview>
+    <IsPreview Condition="$(MicrosoftDotnetSdkInternalPackageVersion.Contains('-rc'))">True</IsPreview>
+    <IsPreview Condition="$(MicrosoftDotnetSdkInternalPackageVersion.Contains('-alpha'))">True</IsPreview>
+    <PreviewTag Condition=" '$(IsPreview)' == 'True' ">$(MicrosoftDotnetSdkInternalPackageVersion.Replace(`-`, `.`).Split(`.`)[3])</PreviewTag>
+    <PreviewTagVersion Condition=" '$(IsPreview)' == 'True' ">$(MicrosoftDotnetSdkInternalPackageVersion.Replace(`-`, `.`).Split(`.`)[4])</PreviewTagVersion>
+    <DotNetPreviewVersionBand Condition=" '$(IsPreview)' == 'True' ">$(DotNetPreviewVersionBand)-$(PreviewTag).$(PreviewTagVersion)</DotNetPreviewVersionBand>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
### Summary

Update Hotfix (https://github.com/Samsung/Tizen.NET/commit/a325174b2f5e2ab6412b3b1beec0a5dcfa558a46) which modified dotnet version band to hard coded value for the urgent NET 7.0 workload release.
This PR gets back to this to the formal code that can now also cover the featured version band to support NET 7.0.