### PR TITLE
[net7.0] Enable net6.0 build on net7.0

### DIFF
--- a/workload/NuGet.config
+++ b/workload/NuGet.config
@@ -6,6 +6,7 @@
     <add key="tizen-myget" value="https://tizen.myget.org/F/dotnet/api/v3/index.json" protocolVersion="3" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
@@ -57,7 +57,7 @@ Copyright (c) Samsung All rights reserved.
       Include="Samsung.Tizen"
       TargetFramework="net6.0-tizen$(_DefaultTargetPlatformVersion)"
       TargetingPackName="Samsung.Tizen.Ref"
-      TargetingPackVersion="**FromWorkload**"
+      TargetingPackVersion="7.0.303"
       Profile="Tizen"
     />
     <KnownFrameworkReference

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
@@ -32,6 +32,14 @@ Copyright (c) Samsung All rights reserved.
     <FrameworkReference Update="Microsoft.NETCore.App" RuntimePackLabels="Tizen" />
     <KnownRuntimePack Remove="Microsoft.NETCore.App" />
     <KnownRuntimePack Include="Microsoft.NETCore.App"
+                      TargetFramework="net6.0"
+                      RuntimeFrameworkName="Microsoft.NETCore.App"
+                      LatestRuntimeFrameworkVersion="**FromWorkload**"
+                      RuntimePackNamePatterns="Samsung.NETCore.App.Runtime.**RID**"
+                      RuntimePackRuntimeIdentifiers="tizen"
+                      RuntimePackLabels="Tizen"
+                      />
+    <KnownRuntimePack Include="Microsoft.NETCore.App"
                       TargetFramework="net7.0"
                       RuntimeFrameworkName="Microsoft.NETCore.App"
                       LatestRuntimeFrameworkVersion="**FromWorkload**"

--- a/workload/src/Samsung.Tizen.Templates/tizen/.template.config/template.json
+++ b/workload/src/Samsung.Tizen.Templates/tizen/.template.config/template.json
@@ -21,6 +21,23 @@
       "description": "Overrides the package name in the tizen-manifest.xml",
       "datatype": "string",
       "replaces": "com.companyname.TizenApp1"
+    },
+    "framework": {
+      "type": "parameter",
+      "description": "Decide the target framework version",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "target framework version is net6.0-tizen"
+        },
+        {
+          "choice": "net7.0",
+          "description": "target framework version is net7.0-tizen"
+        }
+      ],
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     }
   },
   "defaultName": "TizenApp1"


### PR DESCRIPTION
### Summary
- Support building NET 6.0 (net6.0-tizen TFM) application on .NET 7.0.
  - Use the Tizen ref released in the stable dotnet sdk 6.0.300 reference when build net6.0 application in .NET 7.0
- Support '--framework" option to Tizen template to provide net6.0 template.
  - ~$ dotnet new tizen --framework net6.0 
  - ~$ dotnet new tizen --framework net7.0