### PR TITLE
[.NET7] Bump up dotnet sdk to preview7

### DIFF
--- a/.github/workflows/build-workload.yml
+++ b/.github/workflows/build-workload.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
     - main
+    - net7.0
     paths:
     - 'workload/**'
     - '.github/workflows/**'
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
+    - net7.0
     paths:
     - 'workload/**'
     - '.github/workflows/**'

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -33,7 +33,7 @@
     Dotnet SDK versions for building the workload.
    -->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-preview.6.22277.6</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-preview.7.22329.1</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
 </Project>

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -33,7 +33,7 @@ $LatestVersionMap = @{
     "$ManifestBaseName-6.0.200" = "7.0.100-preview.13.6";
     "$ManifestBaseName-6.0.300" = "7.0.303"
     "$ManifestBaseName-6.0.400" = "7.0.400-preview.1.0"
-    "$ManifestBaseName-7.0.100-preview.6" = "7.0.100-preview.6.7";
+    "$ManifestBaseName-7.0.100-preview.6" = "7.0.100-preview.6.14";
 }
 
 function New-TemporaryDirectory {

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -31,8 +31,8 @@ $SupportedDotnetVersion = [Version]"6.0"
 $LatestVersionMap = @{
     "$ManifestBaseName-6.0.100" = "6.5.100-rc.1.120";
     "$ManifestBaseName-6.0.200" = "7.0.100-preview.13.6";
-    "$ManifestBaseName-6.0.300" = "7.0.303"
-    "$ManifestBaseName-6.0.400" = "7.0.400-preview.1.0"
+    "$ManifestBaseName-6.0.300" = "7.0.303";
+    "$ManifestBaseName-6.0.400" = "7.0.400-preview.1.0";
     "$ManifestBaseName-7.0.100-preview.6" = "7.0.100-preview.6.14";
 }
 
@@ -229,3 +229,5 @@ if (Test-Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads
 
 # Clean up
 Remove-Item -Path $TempDir -Force -Recurse
+
+Write-Host "Done installing Tizen workload $Version"

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -128,7 +128,7 @@ LatestVersionMap=(
     "$MANIFEST_BASE_NAME-6.0.200=7.0.100-preview.13.6"
     "$MANIFEST_BASE_NAME-6.0.300=7.0.303"
     "$MANIFEST_BASE_NAME-6.0.400=7.0.400-preview.1.0"
-    "$MANIFEST_BASE_NAME-7.0.100-preview.6=7.0.100-preview.6.7"
+    "$MANIFEST_BASE_NAME-7.0.100-preview.6=7.0.100-preview.6.14"
     )
 
 function getLatestVersion () {
@@ -186,3 +186,5 @@ $DOTNET_INSTALL_DIR/dotnet workload install tizen --skip-manifest-update
 
 # Clean-up
 rm -fr $TMPDIR
+
+echo "Done installing Tizen workload $MANIFEST_VERSION"

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
@@ -45,7 +45,6 @@ Copyright (c) Samsung All rights reserved.
   </ItemGroup>
 
   <ItemGroup>
-
     <KnownFrameworkReference
       Include="Samsung.Tizen"
       TargetFramework="net7.0-tizen7.0"


### PR DESCRIPTION

- Bump up dotnet sdk version to `7.0.100-preview.7.22329.1`
- Update the latest version map.
- Add `net7.0` branch to trigger an Action