### PR TITLE
Fix version issue for net7 in CI environment

### DIFF
--- a/workload/Config.mk
+++ b/workload/Config.mk
@@ -48,7 +48,7 @@ CURRENT_HASH := $(shell git log -1 --pretty=%h)
 
 # BRANCH_NAME
 ifeq ($(BRANCH_NAME),)
-	BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
+	BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD | sed 's/.*\///')
 else
 	BRANCH_NAME := $(BRANCH_NAME)
 endif


### PR DESCRIPTION

This PR changes getting branch name used for creating nuget package in CI or local test environment to fix issue caused when the branch name has `/` symbol.

`main` -> `main`
`heads/net7.0` -> `net7.0`
`releases/6.0.0` ->`6.0.0`

In the CI or the local test environment , we create the special version to be used in the test.
However, for the branches other than main branch would have branch HEAD, for example `heads/net7.0`, `releases/xxxx `.
 `/` symbol in the branchs causes issues when create the nuget packages.
