### PR TITLE
Add check workload installed

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -196,16 +196,17 @@ if (Test-Path $TizenManifestFile) {
     $ManifestJson = $(Get-Content $TizenManifestFile | ConvertFrom-Json)
     $OldVersion = $ManifestJson.version
     if ($OldVersion -eq $Version) {
-        $DotnetWorkloadList = Invoke-Expression "& '$DotnetCommand' workload list"
+        $DotnetWorkloadList = Invoke-Expression "& '$DotnetCommand' workload list | Select-String 'tizen'"
         foreach ($Item in $DotnetWorkloadList)
         {
-            if ($Item.StartsWith("tizen"))
+            if ($Item.Line.StartsWith("tizen"))
             {
                 Write-Host "$Version version is already installed."
                 Exit 0
             }
         }
     }
+
     Write-Host "Removing $ManifestName/$OldVersion from $ManifestDir..."
     Remove-Pack -Id $ManifestName -Version $OldVersion -Kind "manifest"
     $ManifestJson.packs.PSObject.Properties | ForEach-Object {

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -195,16 +195,22 @@ Ensure-Directory $ManifestDir
 if (Test-Path $TizenManifestFile) {
     $ManifestJson = $(Get-Content $TizenManifestFile | ConvertFrom-Json)
     $OldVersion = $ManifestJson.version
-    if ($OldVersion -ne $Version) {
-        Write-Host "Removing $ManifestName/$OldVersion from $ManifestDir..."
-        Remove-Pack -Id $ManifestName -Version $OldVersion -Kind "manifest"
-        $ManifestJson.packs.PSObject.Properties | ForEach-Object {
-            Write-Host "Removing $($_.Name)/$($_.Value.version)..."
-            Remove-Pack -Id $_.Name -Version $_.Value.version -Kind $_.Value.kind
+    if ($OldVersion -eq $Version) {
+        $DotnetWorkloadList = Invoke-Expression "& '$DotnetCommand' workload list"
+        foreach ($Item in $DotnetWorkloadList)
+        {
+            if ($Item.StartsWith("tizen"))
+            {
+                Write-Host "$Version version is already installed."
+                Exit 0
+            }
         }
-    } else {
-        Write-Host "$Version version is already installed."
-        Exit 0
+    }
+    Write-Host "Removing $ManifestName/$OldVersion from $ManifestDir..."
+    Remove-Pack -Id $ManifestName -Version $OldVersion -Kind "manifest"
+    $ManifestJson.packs.PSObject.Properties | ForEach-Object {
+        Write-Host "Removing $($_.Name)/$($_.Value.version)..."
+        Remove-Pack -Id $_.Name -Version $_.Value.version -Kind $_.Value.kind
     }
 }
 

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -196,14 +196,11 @@ if (Test-Path $TizenManifestFile) {
     $ManifestJson = $(Get-Content $TizenManifestFile | ConvertFrom-Json)
     $OldVersion = $ManifestJson.version
     if ($OldVersion -eq $Version) {
-        $DotnetWorkloadList = Invoke-Expression "& '$DotnetCommand' workload list | Select-String 'tizen'"
-        foreach ($Item in $DotnetWorkloadList)
+        $DotnetWorkloadList = Invoke-Expression "& '$DotnetCommand' workload list | Select-String -Pattern '^tizen'"
+        if ($DotnetWorkloadList)
         {
-            if ($Item.Line.StartsWith("tizen"))
-            {
-                Write-Host "$Version version is already installed."
-                Exit 0
-            }
+            Write-Host "$Version version is already installed."
+            Exit 0
         }
     }
 


### PR DESCRIPTION
## Summary
Problem : Install break occurred when reinstall workload.
Cause : manifest directory remaining after workload uninstall.
Solution : Add check workload installed as same version.
