### PR TITLE
[.NET7] Bump up dotnet sdk version to rc1

### DIFF
--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -33,7 +33,7 @@
     Dotnet SDK versions for building the workload.
    -->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-preview.7.22329.1</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-rc.1.22362.32</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bump up dotnet sdk version to `7.0.100-rc.1.22362.32`