### PR TITLE
Fix install script

### DIFF
--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -188,12 +188,24 @@ function install_tizenworkload() {
     fi
 
     # Install workload packs.
+    if [ -f global.json ]; then
+        CACHE_GLOBAL_JSON="true"
+        mv global.json global.json.bak
+    else
+        CACHE_GLOBAL_JSON="false"
+    fi
+    dotnet new globaljson --sdk-version $DOTNET_VERSION
     $DOTNET_INSTALL_DIR/dotnet workload install tizen --skip-manifest-update
 
     # Clean-up
     rm -fr $TMPDIR
+    rm global.json
+    if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then
+        mv global.json.bak global.json
+    fi
 
     echo "Done installing Tizen workload $MANIFEST_VERSION"
+    echo ""
 }
 
 if [[ "$UPDATE_ALL_WORKLOADS" == "true" ]]; then


### PR DESCRIPTION
## Summary

Fix `workload-install.sh` script 
- If there are several SDKs, for workload updates, the current .NET SDK must be changed.
- To solve the above problem, `global.json` file will be generated and deleted.