### PR TITLE
Update installing metadata for NET7.0

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -35,6 +35,8 @@ $LatestVersionMap = @{
     "$ManifestBaseName-6.0.400" = "7.0.400";
     "$ManifestBaseName-7.0.100-preview.6" = "7.0.100-preview.6.14";
     "$ManifestBaseName-7.0.100-preview.7" = "7.0.100-preview.7.20";
+    "$ManifestBaseName-7.0.100-rc.1" = "7.0.100-rc.1.22";
+    "$ManifestBaseName-7.0.100-rc.2" = "7.0.100-rc.2.24";
 }
 
 function New-TemporaryDirectory {
@@ -203,8 +205,10 @@ function Install-TizenWorkload([string]$DotnetVersion)
     }
 
     # Add tizen to the installed workload metadata.
-    New-Item -Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetTargetVersionBand\InstalledWorkloads\tizen") -Force | Out-Null
-    if (Test-Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetTargetVersionBand\InstallerType\msi")) {
+    # Featured version band for metadata does NOT include any preview specifier.
+    # https://github.com/dotnet/sdk/blob/main/documentation/general/workloads/user-local-workloads.md
+    New-Item -Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstalledWorkloads\tizen") -Force | Out-Null
+    if (Test-Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstallerType\msi")) {
         New-Item -Path "HKLM:\SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\x64\$DotnetTargetVersionBand\tizen" -Force | Out-Null
     }
 

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -20,6 +20,8 @@ LatestVersionMap=(
     "$MANIFEST_BASE_NAME-6.0.400=7.0.400"
     "$MANIFEST_BASE_NAME-7.0.100-preview.6=7.0.100-preview.6.14"
     "$MANIFEST_BASE_NAME-7.0.100-preview.7=7.0.100-preview.7.20"
+    "$MANIFEST_BASE_NAME-7.0.100-rc.1=7.0.100-rc.1.22"
+    "$MANIFEST_BASE_NAME-7.0.100-rc.2=7.0.100-rc.2.24"
     )
 
 while [ $# -ne 0 ]; do


### PR DESCRIPTION
This PR updates the install steps for NET7.0 in order to fix an issue.

Issue: Installed Tizen workload was not on the installed workload list.
Fixed: For meta data marker file path above NET7.0 does NOT include any preview specifier. 