### PR TITLE
Add RID information to Samsung.Tizen.Ref

### DIFF
--- a/workload/build/Samsung.Tizen.Ref.proj
+++ b/workload/build/Samsung.Tizen.Ref.proj
@@ -55,6 +55,7 @@ by projects that use the Tizen .NET framework in .NET 5.
     <ItemGroup>
       <_PackageFiles Include="@(_TizenRefPackAssemblies)" PackagePath="ref\net7.0" TargetPath="ref\net7.0" />
       <_PackageFiles Include="$(_ProjectSourceDirectory)Samsung.Tizen.Ref/data/*.txt" PackagePath="data" />
+      <_PackageFiles Include="$(_ProjectSourceDirectory)Samsung.Tizen.Ref/runtime.json" PackagePath=".\" />
     </ItemGroup>
 
   </Target>

--- a/workload/src/Samsung.Tizen.Ref/data/PlatformManifest.txt
+++ b/workload/src/Samsung.Tizen.Ref/data/PlatformManifest.txt
@@ -39,6 +39,7 @@ Tizen.Location.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Location.Geofence.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Log.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.MachineLearning.Inference.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
+Tizen.MachineLearning.Train.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Maps.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Messaging.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Messaging.Push.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
@@ -67,6 +68,7 @@ Tizen.Nlp.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.NUI.Components.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.NUI.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.NUI.Extension.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
+Tizen.NUI.Scene3D.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.NUI.Wearable.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.NUI.WindowSystem.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.PhonenumberUtils.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
@@ -84,6 +86,7 @@ Tizen.System.Information.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.System.MediaKey.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.System.PlatformConfig.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.System.PowerUsage.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
+Tizen.System.Resource.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.System.Storage.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.System.SystemSettings.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.System.Usb.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
@@ -91,6 +94,7 @@ Tizen.Telephony.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Tracer.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Uix.InputMethod.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Uix.InputMethodManager.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
+Tizen.Uix.Sticker.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Uix.Stt.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Uix.SttEngine.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0
 Tizen.Uix.Tts.dll|Samsung.Tizen.Ref|4.0.0.0|4.0.0.0

--- a/workload/src/Samsung.Tizen.Ref/runtime.json
+++ b/workload/src/Samsung.Tizen.Ref/runtime.json
@@ -1,0 +1,147 @@
+{
+  "runtimes": {
+    "tizen": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "tizen-armel": {
+      "#import": [
+        "tizen",
+        "linux-armel"
+      ]
+    },
+    "tizen-x86": {
+      "#import": [
+        "tizen",
+        "linux-x86"
+      ]
+    },
+    "tizen-arm64": {
+      "#import": [
+        "tizen",
+        "linux-arm64"
+      ]
+    },
+    "tizen.4.0.0": {
+      "#import": [
+        "tizen"
+      ]
+    },
+    "tizen.4.0.0-armel": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-armel"
+      ]
+    },
+    "tizen.4.0.0-x86": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-x86"
+      ]
+    },
+    "tizen.5.0.0": {
+      "#import": [
+        "tizen.4.0.0"
+      ]
+    },
+    "tizen.5.0.0-armel": {
+      "#import": [
+        "tizen.5.0.0",
+        "tizen.4.0.0-armel"
+      ]
+    },
+    "tizen.5.0.0-x86": {
+      "#import": [
+        "tizen.5.0.0",
+        "tizen.4.0.0-x86"
+      ]
+    },
+    "tizen.5.5.0": {
+      "#import": [
+        "tizen.5.0.0"
+      ]
+    },
+    "tizen.5.5.0-armel": {
+      "#import": [
+        "tizen.5.5.0",
+        "tizen.5.0.0-armel"
+      ]
+    },
+    "tizen.5.5.0-x86": {
+      "#import": [
+        "tizen.5.5.0",
+        "tizen.5.0.0-x86"
+      ]
+    },
+    "tizen.6.0.0": {
+      "#import": [
+        "tizen.5.5.0"
+      ]
+    },
+    "tizen.6.0.0-armel": {
+      "#import": [
+        "tizen.6.0.0",
+        "tizen.5.5.0-armel"
+      ]
+    },
+    "tizen.6.0.0-x86": {
+      "#import": [
+        "tizen.6.0.0",
+        "tizen.5.5.0-x86"
+      ]
+    },
+    "tizen.6.0.0-arm64": {
+      "#import": [
+        "tizen.6.0.0",
+        "tizen-arm64"
+      ]
+    },
+    "tizen.6.5.0": {
+      "#import": [
+        "tizen.6.0.0"
+      ]
+    },
+    "tizen.6.5.0-armel": {
+      "#import": [
+        "tizen.6.5.0",
+        "tizen.6.0.0-armel"
+      ]
+    },
+    "tizen.6.5.0-x86": {
+      "#import": [
+        "tizen.6.5.0",
+        "tizen.6.0.0-x86"
+      ]
+    },
+    "tizen.6.5.0-arm64": {
+      "#import": [
+        "tizen.6.5.0",
+        "tizen.6.0.0-arm64"
+      ]
+    },
+    "tizen.7.0.0": {
+      "#import": [
+        "tizen.6.5.0"
+      ]
+    },
+    "tizen.7.0.0-armel": {
+      "#import": [
+        "tizen.7.0.0",
+        "tizen.6.5.0-armel"
+      ]
+    },
+    "tizen.7.0.0-x86": {
+      "#import": [
+        "tizen.7.0.0",
+        "tizen.6.5.0-x86"
+      ]
+    },
+    "tizen.7.0.0-arm64": {
+      "#import": [
+        "tizen.7.0.0",
+        "tizen.6.5.0-arm64"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR
  - adds `runtime.json` including Tizen RID information
  -  packages the file to the root folder of Samsung.Tizen.Ref package

This PR will make it possible to use Tizen7.0.0 related RIDs until https://github.com/dotnet/runtime/pull/76600 is safely merged and released.