### PR TITLE
Workaround for dotnet sdk 7.0.100

### DIFF
--- a/workload/Makefile
+++ b/workload/Makefile
@@ -21,7 +21,7 @@ $(DIRECTORIES):
 DOTNET := $(DOTNET_DESTDIR)/dotnet
 
 $(DOTNET): | $(TMPDIR)/dotnet-install.sh
-	@bash $(TMPDIR)/dotnet-install.sh -v $(DOTNET_VERSION) -i $(DOTNET_DESTDIR)
+	@bash $(TMPDIR)/dotnet-install.sh -v 7.0.100-rtm.22519.39 -i $(DOTNET_DESTDIR)
 
 $(TMPDIR)/dotnet-install.sh: | $(OUTDIR)
 	@curl -o $@ \

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -26,7 +26,7 @@
     This version is used to generate Samsung.Tizen.Ref package.
   -->
   <PropertyGroup>
-    <TizenFXVersion>10.0.0.17515</TizenFXVersion>
+    <TizenFXVersion>10.0.0.17508</TizenFXVersion>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION

- Update dotnet sdk setup path as dotnet sdk 7.0.100 stable is not provided through the install script.
- Update TizenFX version to `10.0.0.17508` which is expected to be for Tizen 7.0.