### PR TITLE
Update default target platform version - net7.0

### DIFF
--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
@@ -13,7 +13,7 @@ Copyright (c) Samsung All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <_DefaultTargetPlatformVersion>8.0</_DefaultTargetPlatformVersion>
+    <_DefaultTargetPlatformVersion>7.0</_DefaultTargetPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -49,14 +49,7 @@ Copyright (c) Samsung All rights reserved.
   <ItemGroup>
     <KnownFrameworkReference
       Include="Samsung.Tizen"
-      TargetFramework="net7.0-tizen$(_DefaultTargetPlatformVersion)"
-      TargetingPackName="Samsung.Tizen.Ref"
-      TargetingPackVersion="**FromWorkload**"
-      Profile="Tizen"
-    />
-    <KnownFrameworkReference
-      Include="Samsung.Tizen"
-      TargetFramework="net6.0-tizen$(_DefaultTargetPlatformVersion)"
+      TargetFramework="$(TargetFramework)"
       TargetingPackName="Samsung.Tizen.Ref"
       TargetingPackVersion="**FromWorkload**"
       Profile="Tizen"

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
@@ -19,6 +19,7 @@ Copyright (c) Samsung All rights reserved.
   <PropertyGroup>
     <TargetPlatformSupported>true</TargetPlatformSupported>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(_DefaultTargetPlatformVersion)</TargetPlatformVersion>
+    <TargetFramework Condition="$(TargetFramework.EndsWith('tizen'))">$(TargetFramework)$(_DefaultTargetPlatformVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/workload/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj
+++ b/workload/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-tizen8.0</TargetFramework>
+    <TargetFramework>net7.0-tizen7.0</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">TizenApp1</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/workload/src/Samsung.Tizen.Templates/tizen/tizen-manifest.xml
+++ b/workload/src/Samsung.Tizen.Templates/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns="http://tizen.org/ns/packages" api-version="8" package="com.companyname.TizenApp1" version="1.0.0">
+<manifest xmlns="http://tizen.org/ns/packages" api-version="7" package="com.companyname.TizenApp1" version="1.0.0">
   <profile name="common" />
   <ui-application appid="com.companyname.TizenApp1"
           exec="TizenApp1.dll"


### PR DESCRIPTION
- Update the default target platform version to `7.0`.
- `7.0` is the latest public released target platform version.
- Update `KnownFrameworkReference` to target the `TargetFramework`
- Update TFM on Sample `net7.0-tizen7.0`