### PR TITLE
fix: Use dotnet workload install --sdk-version instead global.json in scripts.

### DIFF
--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -207,21 +207,10 @@ function install_tizenworkload() {
     fi
 
     # Install workload packs.
-    if [ -f global.json ]; then
-        CACHE_GLOBAL_JSON="true"
-        mv global.json global.json.bak
-    else
-        CACHE_GLOBAL_JSON="false"
-    fi
-    dotnet new globaljson --sdk-version $DOTNET_VERSION
-    $DOTNET_INSTALL_DIR/dotnet workload install tizen --skip-manifest-update
+    $DOTNET_INSTALL_DIR/dotnet workload install tizen --sdk-version $DOTNET_VERSION --skip-manifest-update
 
     # Clean-up
     rm -fr $TMPDIR
-    rm global.json
-    if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then
-        mv global.json.bak global.json
-    fi
 
     echo "Done installing Tizen workload $MANIFEST_VERSION"
     echo ""


### PR DESCRIPTION
> Results vary by SDK version
The dotnet workload commands operate in the context of specific SDK versions. Suppose you have both .NET 6.0.100 SDK and .NET 6.0.200 SDK installed. The dotnet workload commands will give different results depending on which SDK version you select. This behavior applies to major and minor version and feature band differences, not to patch version differences. For example, .NET SDK 6.0.101 and 6.0.102 give the same results, whereas 6.0.100 and 6.0.200 give different results. You can specify the SDK version by using the [global.json file](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json) or the --sdk-version option of the dotnet workload commands.

According to [the documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install), `dotnet workload install` also allows you to specify the `--sdk-version` option instead of using cached `global.json` (which could theoretically lead to errors if execution aborts on the `dotnet workload install` command). 
I also created an issue regarding the missing documentation and what version of dotnet this is available from: https://github.com/dotnet/docs/issues/37498