### PR TITLE
Fix merge manifest error

### DIFF
--- a/workload/src/Samsung.Tizen.Build.Tasks/MergeManifest.cs
+++ b/workload/src/Samsung.Tizen.Build.Tasks/MergeManifest.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -71,11 +70,25 @@ namespace Samsung.Tizen.Build.Tasks
                     }
                     else if (subapp.Name.LocalName == "privileges")
                     {
-                        mainDoc.Root.Element(ns + "privileges").Add(subapp.Descendants(ns + "privilege"));
+                        if (mainDoc.Root.Element(ns + "privileges") == null)
+                        {
+                            mainDoc.Root.Add(subapp);
+                        }
+                        else
+                        {
+                            mainDoc.Root.Element(ns + "privileges").Add(subapp.Descendants(ns + "privilege"));
+                        }
                     }
                     else if (subapp.Name.LocalName == "account")
                     {
-                        mainDoc.Root.Element(ns + "account").Add(subapp.Descendants(ns + "account-provider"));
+                        if (mainDoc.Root.Element(ns + "account") == null)
+                        {
+                            mainDoc.Root.Add(subapp);
+                        }
+                        else
+                        {
+                            mainDoc.Root.Element(ns + "account").Add(subapp.Descendants(ns + "account-provider"));
+                        }
                     }
                     else if (subapp.Name.LocalName == "feature")
                     {


### PR DESCRIPTION
Fix merge manifest error when main project doesn't have privileges and acount.

Updated code is following
```c#
                    else if (subapp.Name.LocalName == "privileges")
                    {
                        if (mainDoc.Root.Element(ns + "privileges") == null)
                        {
                            mainDoc.Root.Add(subapp);
                        }
                        else
                        {
                            mainDoc.Root.Element(ns + "privileges").Add(subapp.Descendants(ns + "privilege"));
                        }
                    }
                    else if (subapp.Name.LocalName == "account")
                    {
                        if (mainDoc.Root.Element(ns + "account") == null)
                        {
                            mainDoc.Root.Add(subapp);
                        }
                        else
                        {
                            mainDoc.Root.Element(ns + "account").Add(subapp.Descendants(ns + "account-provider"));
                        }
                    }
```