### PR TITLE
Update net9.0 support

### DIFF
--- a/.github/workflows/build-workload.yml
+++ b/.github/workflows/build-workload.yml
@@ -4,15 +4,11 @@ on:
   push:
     branches:
     - main
-    - net7.0
-    - net8.0
     paths:
     - 'workload/**'
     - '.github/workflows/**'
   pull_request:
-    branches:
-    - main
-    - net7.0
+    branches: [ main ]
     paths:
     - 'workload/**'
     - '.github/workflows/**'

--- a/.github/workflows/build-workload.yml
+++ b/.github/workflows/build-workload.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
     - main
+    - net9.0
     paths:
     - 'workload/**'
     - '.github/workflows/**'
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
+    - net9.0
     paths:
     - 'workload/**'
     - '.github/workflows/**'

--- a/samples/dotnet-podcasts/src/Services/Podcasts/Podcast.API/Podcast.API.csproj
+++ b/samples/dotnet-podcasts/src/Services/Podcasts/Podcast.API/Podcast.API.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/samples/dotnet-podcasts/src/Services/Podcasts/Podcast.Ingestion.Worker/Podcast.Ingestion.Worker.csproj
+++ b/samples/dotnet-podcasts/src/Services/Podcasts/Podcast.Ingestion.Worker/Podcast.Ingestion.Worker.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />

--- a/workload/Config.mk
+++ b/workload/Config.mk
@@ -6,6 +6,7 @@ $(TMPDIR)/dotnet-version.config: $(TOP)/build/Versions.props
 DOTNET_VERSION_BAND = $(firstword $(subst -, ,$(DOTNET_VERSION)))
 
 IS_PRERELEASE=$(findstring -,$(DOTNET_VERSION))
+IS_RTM=$(findstring -rtm,$(DOTNET_VERSION))
 VERSIONS=$(shell echo $(DOTNET_VERSION) | tr "." "\n")
 ifneq ($(IS_PRERELEASE),)
 	VERSIONS := $(shell echo $(VERSIONS) | tr "-" "\n")
@@ -32,7 +33,11 @@ ifeq ($(MAJOR),6)
 	DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(BAND)
 else
 	ifneq ($(IS_PRERELEASE),)
-		DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(MICRO)-$(PRERELEASE_DOTNET).$(PRERELEASE_DOTNET_VERSION)
+		ifneq ($(IS_RTM),)
+			DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(MICRO)-$(PRERELEASE_DOTNET)
+		else
+			DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(MICRO)-$(PRERELEASE_DOTNET).$(PRERELEASE_DOTNET_VERSION)
+		endif
 	else
 		DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(MICRO)
 	endif

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -26,7 +26,7 @@
     This version is used to generate Samsung.Tizen.Ref package.
   -->
   <PropertyGroup>
-    <TizenFXVersion>11.0.0.18030</TizenFXVersion>
+    <TizenFXVersion>11.0.0.18033</TizenFXVersion>
   </PropertyGroup>
 
   <!--

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -15,7 +15,7 @@
        example: -preview.3.100+sha12345
   -->
   <PropertyGroup>
-    <TizenWorkloadVersion>7.0.125</TizenWorkloadVersion>
+    <TizenWorkloadVersion>8.0.131</TizenWorkloadVersion>
   </PropertyGroup>
 
   <!-- 
@@ -33,7 +33,7 @@
     Dotnet SDK versions for building the workload.
    -->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-alpha.1.23422.20</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>8.0.0-beta.23307.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-alpha.1.23617.1</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>9.0.0-beta.23614.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
 </Project>

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -50,6 +50,9 @@ $LatestVersionMap = @{
     "$ManifestBaseName-8.0.100-preview.7" = "7.0.122";
     "$ManifestBaseName-8.0.100-rc.1" = "7.0.124";
     "$ManifestBaseName-8.0.100-rc.2" = "7.0.125";
+    "$ManifestBaseName-8.0.100-rtm" = "7.0.127";
+    "$ManifestBaseName-8.0.100" = "8.0.130";
+    "$ManifestBaseName-9.0.100" = "8.0.131";
 }
 
 function New-TemporaryDirectory {
@@ -70,29 +73,29 @@ function Ensure-Directory([string]$TestDir) {
 }
 
 function Get-LatestVersion([string]$Id) {
+    $attempts=3
+    $sleepInSeconds=3
+    do
+    {
+        try
+        {
+            $Response = Invoke-WebRequest -Uri https://api.nuget.org/v3-flatcontainer/$Id/index.json -UseBasicParsing | ConvertFrom-Json
+            return $Response.versions | Select-Object -Last 1
+        }
+        catch {
+            Write-Host "Id: $Id"
+            Write-Host "An exception was caught: $($_.Exception.Message)"
+        }
+
+        $attempts--
+        if ($attempts -gt 0) { Start-Sleep $sleepInSeconds }
+    } while ($attempts -gt 0)
+
     if ($LatestVersionMap.ContainsKey($Id))
     {
         Write-Host "Return cached latest version."
         return $LatestVersionMap.$Id
     } else {
-        $attempts=3
-        $sleepInSeconds=3
-        do
-        {
-            try
-            {
-                $Response = Invoke-WebRequest -Uri https://api.nuget.org/v3-flatcontainer/$Id/index.json -UseBasicParsing | ConvertFrom-Json
-                return $Response.versions | Select-Object -Last 1
-            }
-            catch {
-                Write-Host "Id: $Id"
-                Write-Host "An exception was caught: $($_.Exception.Message)"
-            }
-
-            $attempts--
-            if ($attempts -gt 0) { Start-Sleep $sleepInSeconds }
-        } while ($attempts -gt 0)
-
         Write-Error "Wrong Id: $Id"
     }
 }
@@ -160,6 +163,10 @@ function Install-TizenWorkload([string]$DotnetVersion)
             $IsPreviewVersion = $DotnetVersion.Contains("-preview") -or $DotnetVersion.Contains("-rc") -or $DotnetVersion.Contains("-alpha")
             if ($IsPreviewVersion -and ($SplitVersion.Count -ge 4)) {
                 $DotnetTargetVersionBand = $DotnetVersionBand + $SplitVersion[2].SubString(3) + $VersionSplitSymbol + $($SplitVersion[3])
+                $ManifestName = "$ManifestBaseName-$DotnetTargetVersionBand"
+            }
+            elseif ($DotnetVersion.Contains("-rtm") -and ($SplitVersion.Count -ge 3)) {
+                $DotnetTargetVersionBand = $DotnetVersionBand + $SplitVersion[2].SubString(3)
                 $ManifestName = "$ManifestBaseName-$DotnetTargetVersionBand"
             }
             else {

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -52,7 +52,7 @@ $LatestVersionMap = @{
     "$ManifestBaseName-8.0.100-rc.2" = "7.0.125";
     "$ManifestBaseName-8.0.100-rtm" = "7.0.127";
     "$ManifestBaseName-8.0.100" = "8.0.130";
-    "$ManifestBaseName-9.0.100" = "8.0.131";
+    "$ManifestBaseName-9.0.100-alpha.1" = "8.0.131";
 }
 
 function New-TemporaryDirectory {

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -37,6 +37,7 @@ LatestVersionMap=(
     "$MANIFEST_BASE_NAME-8.0.100-rc.2=7.0.125"
     "$MANIFEST_BASE_NAME-8.0.100-rtm=7.0.127"
     "$MANIFEST_BASE_NAME-8.0.100=8.0.130"
+    "$MANIFEST_BASE_NAME-9.0.100-alpha.1=8.0.131"
     )
 
 while [ $# -ne 0 ]; do

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -35,6 +35,8 @@ LatestVersionMap=(
     "$MANIFEST_BASE_NAME-8.0.100-preview.7=7.0.122"
     "$MANIFEST_BASE_NAME-8.0.100-rc.1=7.0.124"
     "$MANIFEST_BASE_NAME-8.0.100-rc.2=7.0.125"
+    "$MANIFEST_BASE_NAME-8.0.100-rtm=7.0.127"
+    "$MANIFEST_BASE_NAME-8.0.100=8.0.130"
     )
 
 while [ $# -ne 0 ]; do

--- a/workload/src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml
+++ b/workload/src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml
@@ -1,2 +1,2 @@
-<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="7.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime">
+<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="9.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime">
 </FileList>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets
@@ -17,6 +17,8 @@ Copyright (c) Samsung All rights reserved.
   <PropertyGroup>
     <AssetTargetFallback></AssetTargetFallback>
     <PackageTargetFallback>
+      net9.0-tizen8.0;
+      net9.0-tizen7.0;
       net8.0-tizen8.0;
       net8.0-tizen7.0;
       net7.0-tizen8.0;

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets
@@ -40,12 +40,14 @@ Copyright (c) Samsung All rights reserved.
     <SupportedAPILevel Include="v9.0" MappedAPIVersion="6.5"/>
     <SupportedAPILevel Include="v10.0" MappedAPIVersion="7.0"/>
     <SupportedAPILevel Include="v11.0" MappedAPIVersion="8.0"/>
+    <SupportedAPILevel Include="v12.0" MappedAPIVersion="9.0"/>
   </ItemGroup>
 
   <ItemGroup>
     <TizenSdkSupportedTargetPlatformVersion Include="6.5" />
     <TizenSdkSupportedTargetPlatformVersion Include="7.0" />
     <TizenSdkSupportedTargetPlatformVersion Include="8.0" />
+    <TizenSdkSupportedTargetPlatformVersion Include="9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
@@ -55,6 +55,14 @@ Copyright (c) Samsung All rights reserved.
                       RuntimePackRuntimeIdentifiers="tizen"
                       RuntimePackLabels="Tizen"
                       />
+    <KnownRuntimePack Include="Microsoft.NETCore.App"
+                      TargetFramework="net9.0"
+                      RuntimeFrameworkName="Microsoft.NETCore.App"
+                      LatestRuntimeFrameworkVersion="**FromWorkload**"
+                      RuntimePackNamePatterns="Samsung.NETCore.App.Runtime.**RID**"
+                      RuntimePackRuntimeIdentifiers="tizen"
+                      RuntimePackLabels="Tizen"
+                      />
   </ItemGroup>
 
 </Project>

--- a/workload/src/Samsung.Tizen.Templates/tizen/.template.config/template.json
+++ b/workload/src/Samsung.Tizen.Templates/tizen/.template.config/template.json
@@ -38,10 +38,14 @@
         {
           "choice": "net8.0",
           "description": "target framework version is net8.0-tizen"
+        },
+        {
+          "choice": "net9.0",
+          "description": "target framework version is net9.0-tizen"
         }
       ],
-      "replaces": "net8.0",
-      "defaultValue": "net8.0"
+      "replaces": "net9.0",
+      "defaultValue": "net9.0"
     }
   },
   "defaultName": "TizenApp1"


### PR DESCRIPTION
Prepare tizen workload version `8.0.131` for dotnet SDK `9.0.100-alpha.1.23617.1`.

Update
- Tizen workload version `8.0.131`
- Dotnet sdk version`9.0.100-alpha.1.23617.1`
- MicrosoftDotNetBuildTasksFeedPackageVersion `9.0.0-beta.23614.6`
- Referenced TizenFX API11 `11.0.0.18033`
- Support `net9.0-tizen8.0` tfm
