### PR TITLE
[Actions] Update runner image Ubuntu22.04

### DIFF
--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
- Deprecated actions runner image Ubuntu20.04
- https://github.com/actions/runner-images/issues/11101