### PR TITLE
Add support for .NET SDKs 8, 9 and 10 in script

### DIFF
--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -62,6 +62,7 @@ $LatestVersionMap = [ordered]@{
     "$ManifestBaseName-9.0.100" = "10.0.104";
     "$ManifestBaseName-9.0.200" = "10.0.110";
     "$ManifestBaseName-9.0.300" = "10.0.111";
+    "$ManifestBaseName-10.0.100" = "10.0.123";
 }
 
 function New-TemporaryDirectory {
@@ -297,7 +298,7 @@ if (Get-Command $DotnetCommand -ErrorAction SilentlyContinue)
 {
     if ($UpdateAllWorkloads.IsPresent)
     {
-        $InstalledDotnetSdks = Invoke-Expression "& '$DotnetCommand' --list-sdks | Select-String -Pattern '^6|^7'" | ForEach-Object {$_ -replace (" \[.*","")}
+        $InstalledDotnetSdks = Invoke-Expression "& '$DotnetCommand' --list-sdks | Select-String -Pattern '^6|^7|^8|^9|^10'" | ForEach-Object {$_ -replace (" \[.*","")}
     }
     else
     {

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -46,6 +46,7 @@ LatestVersionMap=(
     "$MANIFEST_BASE_NAME-9.0.100=10.0.104"
     "$MANIFEST_BASE_NAME-9.0.200=10.0.110"
     "$MANIFEST_BASE_NAME-9.0.300=10.0.111"
+    "$MANIFEST_BASE_NAME-10.0.100=10.0.123"
     )
 
 while [ $# -ne 0 ]; do
@@ -251,7 +252,7 @@ function install_tizenworkload() {
 }
 
 if [[ "$UPDATE_ALL_WORKLOADS" == "true" ]]; then
-    INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --list-sdks | sed -n '/^6\|^7/p' | sed 's/ \[.*//g')
+    INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --list-sdks | sed -n '/^6\|^7\|^8\|^9\|^10/p' | sed 's/ \[.*//g')
 else
     INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --version)
 fi


### PR DESCRIPTION
This pull request updates the `workload-install.ps1` script to add support for .NET 10 SDKs. The most significant changes are the addition of a new manifest version mapping for .NET 10 and the inclusion of .NET 8, 9, and 10 in the list of SDKs considered for updates.

**.NET 10 Support:**

* Added a new entry to the `$LatestVersionMap` for `"$ManifestBaseName-10.0.100"` mapped to version `"10.0.123"`.

**SDK Update Logic:**

* Updated the pattern in the SDK listing logic to include .NET 8, 9, and 10 (`^8|^9|^10`), ensuring these versions are recognized when updating all workloads.

* Fixes #301 