### PR TITLE
Support the .NET 11 SDK band and net11.0-tizen TFMs

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -78,6 +78,9 @@ jobs:
     - name: Run test-package-fallback.sh
       run: bash workload/scripts/test-package-fallback.sh
 
+    - name: Run test-release-workflow.sh
+      run: bash workload/scripts/test-release-workflow.sh
+
     - name: Run test-install-failure.sh
       run: bash workload/scripts/test-install-failure.sh
 

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -39,8 +39,21 @@ jobs:
   validate-metadata:
     name: Validate workload metadata
     runs-on: ubuntu-22.04
+    outputs:
+      net11_sdk: ${{ steps.versions.outputs.net11_sdk }}
     steps:
     - uses: actions/checkout@v3
+
+    - name: Resolve .NET 11 SDK version from Versions.props
+      id: versions
+      run: |
+        NET11=$(grep -oP '(?<=<DotNet11SdkVersion>)[^<]+' workload/build/Versions.props)
+        if [ -z "$NET11" ]; then
+          echo "::error::DotNet11SdkVersion not found in workload/build/Versions.props"
+          exit 1
+        fi
+        echo "net11_sdk=$NET11" >> "$GITHUB_OUTPUT"
+        echo "::notice ::.NET 11 SDK for CI: $NET11"
 
     - name: Authenticate GitHub Packages NuGet source
       run: |
@@ -53,27 +66,34 @@ jobs:
     - name: Run validate-workload-metadata.py
       run: python3 workload/scripts/validate-workload-metadata.py
 
+    - name: Run test-matrix.sh --self-test
+      run: bash workload/scripts/test-matrix.sh --self-test
+
     - name: Run test-version-band.sh
       run: bash workload/scripts/test-version-band.sh
+
+    - name: Run test-template-conditions.sh
+      run: bash workload/scripts/test-template-conditions.sh
+
+    - name: Run test-install-failure.sh
+      run: bash workload/scripts/test-install-failure.sh
 
   test-matrix:
     name: Multi-TFM build matrix (${{ matrix.name }})
     needs: validate-metadata
     runs-on: ubuntu-22.04
-    continue-on-error: ${{ matrix.experimental }}
+    # The .NET 11 leg is advisory only while the branch targets a shipping band. On a
+    # net11.0 branch (or a PR into one) .NET 11 is the product, so it must block.
+    continue-on-error: ${{ matrix.experimental && !(github.ref_name == 'net11.0' || github.base_ref == 'net11.0') }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Shipping band. Blocking.
           - name: .NET 10
             dotnet_version: ''
             experimental: false
-          # .NET 11 is still a preview SDK band, so a failure here must not block
-          # merges to the .NET 10 branch. It builds the workload against the .NET 11
-          # SDK and runs the net11.0-* matrix rows end to end.
           - name: .NET 11 preview
-            dotnet_version: '11.0.100-preview.7.26381.103'
+            dotnet_version: ${{ needs.validate-metadata.outputs.net11_sdk }}
             experimental: true
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -17,6 +17,7 @@ on:
     branches:
     - main
     - net10.0
+    - net11.0
     paths:
     - 'workload/**'
     - '.github/workflows/build-matrix.yml'
@@ -24,6 +25,7 @@ on:
     branches:
     - main
     - net10.0
+    - net11.0
     paths:
     - 'workload/**'
     - '.github/workflows/build-matrix.yml'
@@ -51,10 +53,28 @@ jobs:
     - name: Run validate-workload-metadata.py
       run: python3 workload/scripts/validate-workload-metadata.py
 
+    - name: Run test-version-band.sh
+      run: bash workload/scripts/test-version-band.sh
+
   test-matrix:
-    name: Multi-TFM build matrix
+    name: Multi-TFM build matrix (${{ matrix.name }})
     needs: validate-metadata
     runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Shipping band. Blocking.
+          - name: .NET 10
+            dotnet_version: ''
+            experimental: false
+          # .NET 11 is still a preview SDK band, so a failure here must not block
+          # merges to the .NET 10 branch. It builds the workload against the .NET 11
+          # SDK and runs the net11.0-* matrix rows end to end.
+          - name: .NET 11 preview
+            dotnet_version: '11.0.100-preview.7.26381.103'
+            experimental: true
     steps:
     - uses: actions/checkout@v3
       with:
@@ -71,6 +91,7 @@ jobs:
     - name: Run make test-matrix
       env:
         PULLREQUEST_ID: ${{ github.event.number }}
+        DOTNET_VERSION: ${{ matrix.dotnet_version }}
       working-directory: ./workload
       run: make test-matrix
 
@@ -78,7 +99,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: test-matrix-logs
+        name: test-matrix-logs-${{ matrix.name }}
         path: |
           workload/.tmp/matrix/**/build.log
           workload/.tmp/matrix/**/dotnet-new.log

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -75,6 +75,9 @@ jobs:
     - name: Run test-template-conditions.sh
       run: bash workload/scripts/test-template-conditions.sh
 
+    - name: Run test-package-fallback.sh
+      run: bash workload/scripts/test-package-fallback.sh
+
     - name: Run test-install-failure.sh
       run: bash workload/scripts/test-install-failure.sh
 
@@ -82,9 +85,13 @@ jobs:
     name: Multi-TFM build matrix (${{ matrix.name }})
     needs: validate-metadata
     runs-on: ubuntu-22.04
-    # The .NET 11 leg is advisory only while the branch targets a shipping band. On a
-    # net11.0 branch (or a PR into one) .NET 11 is the product, so it must block.
-    continue-on-error: ${{ matrix.experimental && !(github.ref_name == 'net11.0' || github.base_ref == 'net11.0') }}
+    # The .NET 11 leg BLOCKS by default. The SDK version is pinned exactly
+    # (DotNet11SdkVersion), so the leg is deterministic - and a branch whose purpose is
+    # .NET 11 support gains nothing from an advisory-only .NET 11 gate.
+    #
+    # Set the repository variable TIZEN_NET11_ADVISORY=true to temporarily downgrade it,
+    # e.g. while chasing an upstream preview-SDK regression.
+    continue-on-error: ${{ matrix.experimental && vars.TIZEN_NET11_ADVISORY == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-workload.yml
+++ b/.github/workflows/build-workload.yml
@@ -43,10 +43,31 @@ jobs:
           --store-password-in-clear-text \
           --configfile workload/NuGet.config
 
+    # On a net11.0 branch (or a PR into one) .NET 11 is the product being built, so the
+    # workload must be built against the .NET 11 SDK rather than the Versions.props
+    # default. DotNet11SdkVersion in Versions.props is the single source of truth.
+    - name: Select target SDK band
+      id: sdk
+      run: |
+        TARGET_BRANCH="${{ github.base_ref || github.ref_name }}"
+        if [ "$TARGET_BRANCH" = "net11.0" ]; then
+          NET11=$(grep -oP '(?<=<DotNet11SdkVersion>)[^<]+' workload/build/Versions.props)
+          if [ -z "$NET11" ]; then
+            echo "::error::DotNet11SdkVersion not found in workload/build/Versions.props"
+            exit 1
+          fi
+          echo "dotnet_version=$NET11" >> "$GITHUB_OUTPUT"
+          echo "::notice ::Branch '$TARGET_BRANCH' builds against .NET 11 SDK $NET11"
+        else
+          echo "dotnet_version=" >> "$GITHUB_OUTPUT"
+          echo "::notice ::Branch '$TARGET_BRANCH' builds against the Versions.props default SDK band"
+        fi
+
     - name: Build
       env:
         PULLREQUEST_ID: ${{ github.event.number }}
         PRERELEASE_TAG: ${{ github.event.inputs.prerelease }}
+        DOTNET_VERSION: ${{ steps.sdk.outputs.dotnet_version }}
       run: make test
       working-directory: ./workload
 

--- a/.github/workflows/build-workload.yml
+++ b/.github/workflows/build-workload.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - main
     - net10.0
+    - net11.0
     paths:
     - 'workload/**'
     - '.github/workflows/**'
@@ -12,6 +13,7 @@ on:
     branches:
     - main
     - net10.0
+    - net11.0
     paths:
     - 'workload/**'
     - '.github/workflows/**'

--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -57,33 +57,69 @@ jobs:
     - name: Install Wix toolset
       run: sudo apt-get install -y wixl
 
+    # A release must never publish a half-built or stale set of packages. The tree is
+    # cleaned first so the output directory can only contain this run's artifacts, and
+    # the build is NOT continue-on-error: a failed build must abort the release.
+    - name: Clean previous output
+      run: make clean
+      working-directory: ./workload
+
     - name: Build
       env:
         PRERELEASE_TAG: "stable"
       run: make install -d DOTNET_VERSION=${{ github.event.inputs.net_sdk_version }}
       working-directory: ./workload
-      continue-on-error: true
+
+    # Stage into an isolated directory and verify the expected artifacts exist, so the
+    # push steps operate on an explicit, audited list rather than a glob over whatever
+    # happens to be on disk.
+    - name: Stage and verify packages
+      id: stage
+      run: |
+        set -euo pipefail
+        STAGING="$RUNNER_TEMP/staging"
+        rm -rf "$STAGING" && mkdir -p "$STAGING"
+        shopt -s nullglob
+        pkgs=(./workload/out/nuget-unsigned/*.nupkg)
+        if [ ${#pkgs[@]} -eq 0 ]; then
+          echo "::error::Build produced no packages."
+          exit 1
+        fi
+        cp "${pkgs[@]}" "$STAGING/"
+        SDK="${{ github.event.inputs.net_sdk_version }}"
+        # Reuse the band function from workload-install.sh so the release cannot
+        # disagree with what the installer will look for.
+        eval "$(sed -n '/# BEGIN VERSION BAND DETECTION/,/# END VERSION BAND DETECTION/p' workload/scripts/workload-install.sh)"
+        BAND="$(compute_target_version_band "$SDK")"
+        echo "Resolved SDK feature band: $BAND"
+        if ! ls "$STAGING/Samsung.NET.Sdk.Tizen.Manifest-$BAND."*.nupkg >/dev/null 2>&1; then
+          echo "::error::No Samsung.NET.Sdk.Tizen.Manifest-$BAND package was produced."
+          ls -1 "$STAGING"
+          exit 1
+        fi
+        echo "staging=$STAGING" >> "$GITHUB_OUTPUT"
+        echo "Staged packages:"; ls -1 "$STAGING"
 
     - name: Push Manifest/SDK/Runtime packs
       if: ${{ github.event.inputs.release_manifest == 'true' }}
       run: |
         echo "Pushing Manifest packs for version ${{ github.event.inputs.net_sdk_version }}"...
-        dotnet nuget push ./workload/out/nuget-unsigned/Samsung.NET.Sdk.Tizen.Manifest-*.nupkg \
+        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.NET.Sdk.Tizen.Manifest-*.nupkg \
                       -k ${{ secrets.NUGET_APIKEY }} \
                       -s https://api.nuget.org/v3/index.json \
                       -t 3000 \
                       --skip-duplicate
-        dotnet nuget push ./workload/out/nuget-unsigned/Samsung.Tizen.Sdk.*.nupkg \
+        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.Tizen.Sdk.*.nupkg \
                       -k ${{ secrets.NUGET_APIKEY }} \
                       -s https://api.nuget.org/v3/index.json \
                       -t 3000 \
                       --skip-duplicate
-        dotnet nuget push ./workload/out/nuget-unsigned/Samsung.NETCore.App.Runtime.*.nupkg \
+        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.NETCore.App.Runtime.*.nupkg \
                       -k ${{ secrets.NUGET_APIKEY }} \
                       -s https://api.nuget.org/v3/index.json \
                       -t 3000 \
                       --skip-duplicate
-        dotnet nuget push ./workload/out/nuget-unsigned/Samsung.Tizen.Templates.*.nupkg \
+        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.Tizen.Templates.*.nupkg \
                       -k ${{ secrets.NUGET_APIKEY }} \
                       -s https://api.nuget.org/v3/index.json \
                       -t 3000 \
@@ -93,7 +129,7 @@ jobs:
       if: ${{ github.event.inputs.release_reference == 'true' }}
       run: |
         echo "Pushing Manifest packs for version ${{ github.event.inputs.net_sdk_version }}"...
-        dotnet nuget push ./workload/out/nuget-unsigned/Samsung.Tizen.Ref.*.nupkg \
+        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.Tizen.Ref.*.nupkg \
                       -k ${{ secrets.NUGET_APIKEY }} \
                       -s https://api.nuget.org/v3/index.json \
                       -t 3000 \

--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -147,11 +147,13 @@ jobs:
           exit 1
         fi
         cp "${pkgs[@]}" "$STAGING/"
-        SDK="${{ github.event.inputs.net_sdk_version }}"
-        # Reuse the band function from workload-install.sh so the release cannot
-        # disagree with what the installer will look for.
-        eval "$(sed -n '/# BEGIN VERSION BAND DETECTION/,/# END VERSION BAND DETECTION/p' workload/scripts/workload-install.sh)"
-        BAND="$(compute_target_version_band "$SDK")"
+        # Single source: the band the resolve step already computed (via the installer's
+        # own function). Recomputing it here would be a second place to drift.
+        BAND="${{ steps.bump.outputs.band }}"
+        if [ -z "$BAND" ]; then
+          echo "::error::Resolve step did not publish a band output."
+          exit 1
+        fi
         echo "Resolved SDK feature band: $BAND"
         if ! ls "$STAGING/Samsung.NET.Sdk.Tizen.Manifest-$BAND."*.nupkg >/dev/null 2>&1; then
           echo "::error::No Samsung.NET.Sdk.Tizen.Manifest-$BAND package was produced."

--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -39,23 +39,32 @@ jobs:
 
     # Resolve the version to release.
     #
-    # Two properties matter here:
-    #  * A reference-only run (release_manifest=false) publishes no manifest, so it must be
-    #    completely NON-MUTATING - no bump, no commit, no tag.
-    #  * OLD == NEW is NOT necessarily an error. next-workload-version.py derives the next
-    #    version from what is published on NuGet, so if a previous run already bumped and
-    #    pushed but failed before publishing, the branch legitimately carries the intended
-    #    (still unpublished) version. That case must RESUME, not abort - otherwise a failed
-    #    release can never be retried.
+    # Publication is not atomic: the manifest, the remaining packs, the tag and the GitHub
+    # release are separate steps. If one fails partway, version V is PARTIALLY published -
+    # and because next-workload-version.py derives the next version from what exists on
+    # NuGet, it then answers V+1. Advancing at that point strands V forever with no tag,
+    # no release, and a missing pack set.
+    #
+    # So the state of V is determined FIRST, and V is resumed unless it is provably complete:
+    #   unpublished  -> resume V if the branch already carries it, else bump
+    #   partial      -> ALWAYS resume V (never advance)
+    #   published    -> resume only to finish a missing tag/release, otherwise bump
+    #
+    # A feed transport failure exits non-zero rather than being read as "unpublished".
     - name: Resolve release version
       id: bump
       working-directory: ./workload
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
         OLD=$(grep -oP '(?<=<TizenWorkloadVersion>)[^<]+(?=</TizenWorkloadVersion>)' build/Versions.props)
-        NEW=$(python3 scripts/next-workload-version.py)
-        echo "Current: $OLD"
-        echo "Next:    $NEW"
+        echo "Current branch version: $OLD"
+
+        SDK="${{ github.event.inputs.net_sdk_version }}"
+        eval "$(sed -n '/# BEGIN VERSION BAND DETECTION/,/# END VERSION BAND DETECTION/p' scripts/workload-install.sh)"
+        BAND="$(compute_target_version_band "$SDK")"
+        echo "band=$BAND" >> "$GITHUB_OUTPUT"
 
         if [ "${{ github.event.inputs.release_manifest }}" != "true" ]; then
           echo "::notice ::Reference-only run: leaving TizenWorkloadVersion at $OLD (non-mutating)."
@@ -64,14 +73,43 @@ jobs:
           exit 0
         fi
 
-        if [ "$OLD" = "$NEW" ]; then
-          # The branch already holds the version NuGet does not have yet: resume it.
-          echo "::notice ::Resuming release of $OLD (already set on this branch, not yet published)."
+        # Publication state of the version the branch currently carries.
+        STATE_OUT="$(python3 scripts/release-state.py --version "$OLD" --band "$BAND")"
+        STATE="$(echo "$STATE_OUT" | sed -n 's/^state=//p')"
+        MISSING="$(echo "$STATE_OUT" | sed -n 's/^missing=//p')"
+        echo "State of $OLD: $STATE (missing: ${MISSING:-none})"
+        echo "resume_missing=$MISSING" >> "$GITHUB_OUTPUT"
+
+        # Has V already been tagged and released?
+        if gh release view "v$OLD" >/dev/null 2>&1; then RELEASED=true; else RELEASED=false; fi
+        echo "Release v$OLD exists: $RELEASED"
+
+        if [ "$STATE" = "partial" ]; then
+          echo "::warning ::Version $OLD is partially published (missing: $MISSING). Resuming it instead of advancing."
           echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
           echo "mutated=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
+        if [ "$STATE" = "published" ] && [ "$RELEASED" != "true" ]; then
+          echo "::warning ::Version $OLD is fully published but has no release tag. Resuming to complete the tag/release."
+          echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
+          echo "mutated=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        NEW=$(python3 scripts/next-workload-version.py)
+        echo "Next: $NEW"
+
+        if [ "$STATE" = "unpublished" ] && [ "$OLD" = "$NEW" ]; then
+          # The branch already carries an unpublished version: resume it.
+          echo "::notice ::Resuming release of $OLD (set on this branch, nothing published yet)."
+          echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
+          echo "mutated=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # V is complete (published AND released): it is safe to advance.
         python3 scripts/next-workload-version.py --apply --verbose
         echo "workload_version=$NEW" >> "$GITHUB_OUTPUT"
         echo "mutated=true" >> "$GITHUB_OUTPUT"
@@ -155,30 +193,59 @@ jobs:
         git push origin "HEAD:${BRANCH}"
         echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-    - name: Push Manifest/SDK/Runtime packs
+    # Publish every versioned pack. `--skip-duplicate` makes each push idempotent: NuGet
+    # packages are immutable, so an id+version that already exists IS the intended artifact
+    # and is simply skipped. That is what allows a partially published version to be resumed
+    # by re-running with the same version.
+    #
+    # The pushes are ordered so the MANIFEST GOES LAST. The manifest is what
+    # next-workload-version.py keys off, so publishing it only after its companion packs
+    # means an interruption cannot leave a version that looks advanceable while its packs are
+    # missing. Combined with the resume detection above, an interrupted release re-runs
+    # cleanly from any point.
+    - name: Push SDK/Runtime/Templates packs
       if: ${{ github.event.inputs.release_manifest == 'true' }}
       run: |
-        echo "Pushing Manifest packs for version ${{ github.event.inputs.net_sdk_version }}"...
+        set -euo pipefail
+        VER="${{ steps.bump.outputs.workload_version }}"
+        echo "Publishing companion packs for workload version $VER..."
+        for pattern in Samsung.Tizen.Sdk Samsung.NETCore.App.Runtime Samsung.Tizen.Templates; do
+          dotnet nuget push ${{ steps.stage.outputs.staging }}/$pattern.*.nupkg \
+                        -k ${{ secrets.NUGET_APIKEY }} \
+                        -s https://api.nuget.org/v3/index.json \
+                        -t 3000 \
+                        --skip-duplicate
+        done
+
+    - name: Push Manifest pack
+      if: ${{ github.event.inputs.release_manifest == 'true' }}
+      run: |
+        set -euo pipefail
+        echo "Publishing manifest for band ${{ steps.bump.outputs.band }}..."
         dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.NET.Sdk.Tizen.Manifest-*.nupkg \
                       -k ${{ secrets.NUGET_APIKEY }} \
                       -s https://api.nuget.org/v3/index.json \
                       -t 3000 \
                       --skip-duplicate
-        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.Tizen.Sdk.*.nupkg \
-                      -k ${{ secrets.NUGET_APIKEY }} \
-                      -s https://api.nuget.org/v3/index.json \
-                      -t 3000 \
-                      --skip-duplicate
-        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.NETCore.App.Runtime.*.nupkg \
-                      -k ${{ secrets.NUGET_APIKEY }} \
-                      -s https://api.nuget.org/v3/index.json \
-                      -t 3000 \
-                      --skip-duplicate
-        dotnet nuget push ${{ steps.stage.outputs.staging }}/Samsung.Tizen.Templates.*.nupkg \
-                      -k ${{ secrets.NUGET_APIKEY }} \
-                      -s https://api.nuget.org/v3/index.json \
-                      -t 3000 \
-                      --skip-duplicate
+
+    # Confirm the full expected set is actually on the feed before tagging, so a release is
+    # never created for an incomplete publication.
+    - name: Verify publication is complete
+      if: ${{ github.event.inputs.release_manifest == 'true' }}
+      working-directory: ./workload
+      run: |
+        set -euo pipefail
+        VER="${{ steps.bump.outputs.workload_version }}"
+        BAND="${{ steps.bump.outputs.band }}"
+        for attempt in 1 2 3 4 5; do
+          OUT="$(python3 scripts/release-state.py --version "$VER" --band "$BAND")"
+          STATE="$(echo "$OUT" | sed -n 's/^state=//p')"
+          [ "$STATE" = "published" ] && { echo "All expected packages present for $VER."; exit 0; }
+          echo "Attempt $attempt: state=$STATE ($(echo "$OUT" | sed -n 's/^missing=//p')); feed may lag, retrying..."
+          sleep 30
+        done
+        echo "::error::Publication incomplete for $VER; not tagging. Re-run this workflow to resume."
+        exit 1
 
     - name: Push Ref pack
       if: ${{ github.event.inputs.release_reference == 'true' }}

--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -70,13 +70,20 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
-        OLD=$(grep -oP '(?<=<TizenWorkloadVersion>)[^<]+(?=</TizenWorkloadVersion>)' build/Versions.props)
-        echo "Current branch version: $OLD"
-
         SDK="${{ github.event.inputs.net_sdk_version }}"
         eval "$(sed -n '/# BEGIN VERSION BAND DETECTION/,/# END VERSION BAND DETECTION/p' scripts/workload-install.sh)"
         BAND="$(compute_target_version_band "$SDK")"
-        echo "band=$BAND" >> "$GITHUB_OUTPUT"
+        MANIFEST_ID="Samsung.NET.Sdk.Tizen.Manifest-$BAND"
+        PACKAGES="$MANIFEST_ID,Samsung.NETCore.App.Runtime.tizen,Samsung.Tizen.Sdk,Samsung.Tizen.Templates"
+        BRANCH="${GITHUB_REF_NAME}"
+        {
+          echo "band=$BAND"
+          echo "manifest_id=$MANIFEST_ID"
+          echo "packages=$PACKAGES"
+        } >> "$GITHUB_OUTPUT"
+
+        OLD=$(grep -oP '(?<=<TizenWorkloadVersion>)[^<]+(?=</TizenWorkloadVersion>)' build/Versions.props)
+        echo "Branch version at the checked-out commit: $OLD"
 
         # A reference-only run publishes no manifest: fully non-mutating, no reservation.
         if [ "${{ github.event.inputs.release_manifest }}" != "true" ]; then
@@ -86,70 +93,112 @@ jobs:
           exit 0
         fi
 
-        STATE_OUT="$(python3 scripts/release-state.py --version "$OLD" --band "$BAND")"
-        STATE="$(echo "$STATE_OUT" | sed -n 's/^state=//p')"
-        MISSING="$(echo "$STATE_OUT" | sed -n 's/^missing=//p')"
-        echo "State of $OLD: $STATE (missing: ${MISSING:-none})"
+        # ------------------------------------------------------------------
+        # Find an outstanding reservation to resume.
+        #
+        # Resuming used to be decided from $OLD - the version in Versions.props at the
+        # commit this job checked out. That is the wrong source of truth for a re-run:
+        # `Re-run jobs` checks out the SHA of the ORIGINAL event, which is the commit
+        # BEFORE the bump, so $OLD is the previous, already-released version. The re-run
+        # therefore saw "nothing to resume", computed the same candidate again, found its
+        # own reservation ref and aborted as though a stranger held it - leaving the
+        # interrupted release permanently unfinishable.
+        #
+        # The reservation refs are the durable record, so they are enumerated directly and
+        # matched against THIS run's inputs. The checked-out SHA no longer matters.
+        # ------------------------------------------------------------------
+        git fetch --force origin "+refs/tizen-release/*:refs/tizen-release/*" || true
 
-        if gh release view "v$OLD" >/dev/null 2>&1; then RELEASED=true; else RELEASED=false; fi
+        RESUME_VER=""
+        RESUME_SHA=""
+        for ref in $(git for-each-ref --format='%(refname)' 'refs/tizen-release/v*'); do
+          V="${ref##*/v}"
+          git cat-file -p "$ref" > "$RUNNER_TEMP/payload.txt" 2>/dev/null || continue
 
-        RESUME=false
-        if [ "$STATE" = "partial" ]; then
-          echo "::warning ::Version $OLD is partially published (missing: $MISSING). Resuming."
-          RESUME=true
-        elif [ "$STATE" = "published" ] && [ "$RELEASED" != "true" ]; then
-          echo "::warning ::Version $OLD is published but untagged. Resuming to finish the release."
-          RESUME=true
-        elif [ "$STATE" = "unpublished" ] && git ls-remote --exit-code origin "refs/tizen-release/v$OLD" >/dev/null 2>&1; then
-          echo "::notice ::Version $OLD is already reserved on this repository. Resuming."
-          RESUME=true
-        fi
+          # Only consider reservations made for these exact release inputs. A reservation
+          # for another branch, SDK or band belongs to a different release and must never
+          # be adopted by this one.
+          if ! python3 scripts/release-reservation.py verify \
+                 --payload-file "$RUNNER_TEMP/payload.txt" \
+                 --expect-version "$V" \
+                 --expect-sdk "$SDK" \
+                 --expect-band "$BAND" \
+                 --expect-branch "$BRANCH" \
+                 --expect-manifest-id "$MANIFEST_ID" \
+                 --expect-packages "$PACKAGES" >/dev/null 2>&1; then
+            continue
+          fi
 
-        if [ "$RESUME" = "true" ]; then
-          VER="$OLD"
-          # The reservation records the commit the artifacts must be built from. Everything
-          # in a resumed run is rebuilt from that SHA so the retry cannot publish packages
-          # stamped with a different commit than the ones already on the feed.
-          RES_SHA="$(git ls-remote origin "refs/tizen-release/v$VER" | cut -f1)"
-          if [ -z "$RES_SHA" ]; then
-            echo "::error::Resuming $VER but no reservation ref exists. Refusing to guess the release commit."
+          # It is ours. Is it finished?
+          STATE_OUT="$(python3 scripts/release-state.py --version "$V" --band "$BAND")"
+          STATE="$(echo "$STATE_OUT" | sed -n 's/^state=//p')"
+          if gh release view "v$V" >/dev/null 2>&1; then RELEASED=true; else RELEASED=false; fi
+          if [ "$STATE" = "published" ] && [ "$RELEASED" = "true" ]; then
+            continue
+          fi
+
+          if [ -n "$RESUME_VER" ]; then
+            echo "::error::More than one unfinished reservation matches these inputs (v$RESUME_VER and v$V). Resolve this by hand."
             exit 1
           fi
-          echo "Reserved release commit: $RES_SHA"
-          echo "workload_version=$VER" >> "$GITHUB_OUTPUT"
-          echo "release_sha=$RES_SHA" >> "$GITHUB_OUTPUT"
+          RESUME_VER="$V"
+          RESUME_SHA="$(python3 scripts/release-reservation.py verify \
+                          --payload-file "$RUNNER_TEMP/payload.txt" --print-field sha)"
+          echo "::warning ::Reservation v$V is unfinished (state=$STATE, released=$RELEASED). Resuming it."
+        done
+
+        if [ -n "$RESUME_VER" ]; then
+          echo "Resuming v$RESUME_VER from reserved commit $RESUME_SHA"
+          echo "workload_version=$RESUME_VER" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RESUME_SHA" >> "$GITHUB_OUTPUT"
+          echo "resumed=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        # Fresh release: compute the candidate ONCE and write that exact value. Calling the
-        # script a second time with --apply would re-query the feed and could persist a
+        # ------------------------------------------------------------------
+        # Fresh release. Compute the candidate ONCE and write that exact value; calling
+        # the script again with --apply would re-query the feed and could persist a
         # different version if another release landed in between.
+        # ------------------------------------------------------------------
         NEW=$(python3 scripts/next-workload-version.py)
         echo "Candidate: $NEW"
 
         if git ls-remote --exit-code origin "refs/tizen-release/v$NEW" >/dev/null 2>&1; then
-          echo "::error::Version $NEW is already reserved by another release. Aborting."
+          echo "::error::Version $NEW is already reserved by a release with different inputs. Aborting."
           exit 1
         fi
 
+        # An explicit --set-version equal to the value already on disk is a no-op, not a
+        # failure: a previous run bumped the file but never reached the reservation. This
+        # runs OUTSIDE a condition under `set -e`, so a non-zero exit here would kill the
+        # step and make the recovery path below unreachable.
         python3 scripts/next-workload-version.py --apply --set-version "$NEW" --verbose
         cd ..
         git config user.name  "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add workload/build/Versions.props
         if git diff --cached --quiet; then
-          # OLD == NEW: the branch already carries the intended, still-unpublished version
-          # (a previous run bumped but never reserved). There is nothing to commit, so the
-          # current HEAD IS the release commit. Reserve it rather than failing.
           echo "::notice ::TizenWorkloadVersion is already $NEW; reserving the current commit."
         else
           git commit -m "chore: bump TizenWorkloadVersion to ${NEW}"
         fi
         RELEASE_SHA="$(git rev-parse HEAD)"
 
-        # Claim ownership atomically. A non-fast-forward create is rejected, so if two runs
-        # race, exactly one wins and the loser aborts here rather than publishing.
-        if ! git push origin "$RELEASE_SHA:refs/tizen-release/v$NEW"; then
+        # The reservation carries the complete release input set, so a later run can prove
+        # it is entitled to continue this exact release and cannot adopt it for a different
+        # SDK/band/branch.
+        PAYLOAD="$(python3 workload/scripts/release-reservation.py encode \
+                     --version "$NEW" --sha "$RELEASE_SHA" --sdk "$SDK" --band "$BAND" \
+                     --manifest-id "$MANIFEST_ID" --packages "$PACKAGES" --branch "$BRANCH")"
+        git tag -f -a "tizen-reserve-$NEW" -m "tizen-release reservation v$NEW
+
+        $PAYLOAD" "$RELEASE_SHA"
+
+        # Atomic compare-and-swap CREATE: an empty expected value requires the ref to not
+        # exist yet, so if two runs race exactly one wins and the loser aborts here rather
+        # than publishing over someone else's version.
+        if ! git push origin "refs/tags/tizen-reserve-$NEW:refs/tizen-release/v$NEW" \
+               --force-with-lease="refs/tizen-release/v$NEW:"; then
           echo "::error::Failed to reserve $NEW (another release won the race). Aborting."
           exit 1
         fi
@@ -157,6 +206,7 @@ jobs:
 
         echo "workload_version=$NEW" >> "$GITHUB_OUTPUT"
         echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+        echo "resumed=false" >> "$GITHUB_OUTPUT"
         echo "::notice ::Reserved and bumped TizenWorkloadVersion: $OLD -> $NEW at $RELEASE_SHA"
 
     # Build from the RESERVED commit, never from whatever the branch or the re-run event
@@ -359,12 +409,28 @@ jobs:
             [ -n "$v" ] && echo "- https://www.nuget.org/packages/Samsung.Tizen.Ref.API${api}/${v}"
           done
         } > "$RUNNER_TEMP/release-notes.md"
+        SHA="${{ steps.bump.outputs.release_sha }}"
         if gh release view "v${VER}" >/dev/null 2>&1; then
-          echo "::notice ::Release v${VER} already exists; skipping creation (resumed run)."
+          # An existing tag is only the intended artifact if it points at the reserved
+          # commit. Blindly treating "the tag exists" as done would bless a release whose
+          # tag targets a different tree than the packages that were published - exactly
+          # the mixed-provenance state the reservation exists to prevent.
+          git fetch origin "refs/tags/v${VER}:refs/tags/v${VER}" --force >/dev/null 2>&1 || true
+          TAG_SHA="$(git rev-parse "refs/tags/v${VER}^{commit}" 2>/dev/null || echo "")"
+          if [ -z "$TAG_SHA" ]; then
+            echo "::error::Release v${VER} exists but its tag could not be resolved to a commit."
+            exit 1
+          fi
+          if [ "$TAG_SHA" != "$SHA" ]; then
+            echo "::error::Release v${VER} is tagged at $TAG_SHA but this version was reserved at $SHA."
+            echo "::error::Refusing to accept a release whose tag does not match the reserved release commit."
+            exit 1
+          fi
+          echo "::notice ::Release v${VER} already exists at the reserved commit $SHA; nothing to do."
           exit 0
         fi
         gh release create "v${VER}" \
-          --target "${{ steps.bump.outputs.release_sha }}" \
+          --target "$SHA" \
           --title "Tizen Workload ${VER} - .Net ${MAJOR_MINOR}" \
           --notes-file "$RUNNER_TEMP/release-notes.md" \
           --generate-notes

--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -54,6 +54,26 @@ jobs:
         echo "workload_version=$NEW" >> "$GITHUB_OUTPUT"
         echo "::notice ::Bumped TizenWorkloadVersion: $OLD -> $NEW"
 
+    # Persist the bump. Without this the tag created below points at a commit whose
+    # Versions.props still holds the PREVIOUS version, so the released sources do not
+    # correspond to the published package versions.
+    - name: Commit and push the version bump
+      run: |
+        set -e
+        BRANCH="${GITHUB_REF_NAME}"
+        VER="${{ steps.bump.outputs.workload_version }}"
+        if git diff --quiet -- workload/build/Versions.props; then
+          echo "::error::Versions.props was not modified by the bump step."
+          exit 1
+        fi
+        git config user.name  "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add workload/build/Versions.props
+        git commit -m "chore: bump TizenWorkloadVersion to ${VER}"
+        git push origin "HEAD:${BRANCH}"
+        echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      id: commit
+
     - name: Install Wix toolset
       run: sudo apt-get install -y wixl
 
@@ -97,7 +117,11 @@ jobs:
           ls -1 "$STAGING"
           exit 1
         fi
+        MANIFEST_PKG="$(basename "$(ls "$STAGING/Samsung.NET.Sdk.Tizen.Manifest-$BAND."*.nupkg | head -1)")"
         echo "staging=$STAGING" >> "$GITHUB_OUTPUT"
+        echo "band=$BAND" >> "$GITHUB_OUTPUT"
+        echo "manifest_id=Samsung.NET.Sdk.Tizen.Manifest-$BAND" >> "$GITHUB_OUTPUT"
+        echo "manifest_pkg=$MANIFEST_PKG" >> "$GITHUB_OUTPUT"
         echo "Staged packages:"; ls -1 "$STAGING"
 
     - name: Push Manifest/SDK/Runtime packs
@@ -142,14 +166,19 @@ jobs:
       run: |
         VER="${{ steps.bump.outputs.workload_version }}"
         SDK="${{ github.event.inputs.net_sdk_version }}"
-        BAND="${SDK%%-*}"
+        # Canonical feature band and manifest id, as resolved and VERIFIED against the
+        # staged artifacts. Do not recompute here: '${SDK%%-*}' yields '11.0.100' for
+        # 11.0.100-preview.7.* and '10.0.404' for a servicing band, linking to packages
+        # that were never published.
+        BAND="${{ steps.stage.outputs.band }}"
+        MANIFEST_ID="${{ steps.stage.outputs.manifest_id }}"
         MAJOR_MINOR="$(echo "$BAND" | cut -d. -f1-2)"
         {
           echo "### Target .NET SDK: .NET ${SDK}"
           echo ""
           echo "## NuGet Packages"
           echo ""
-          echo "- https://www.nuget.org/packages/Samsung.NET.Sdk.Tizen.Manifest-${BAND}/${VER}"
+          echo "- https://www.nuget.org/packages/${MANIFEST_ID}/${VER}"
           echo "- https://www.nuget.org/packages/Samsung.NETCore.App.Runtime.tizen/${VER}"
           echo "- https://www.nuget.org/packages/Samsung.Tizen.Sdk/${VER}"
           echo "- https://www.nuget.org/packages/Samsung.Tizen.Templates/${VER}"
@@ -159,7 +188,7 @@ jobs:
           done
         } > "$RUNNER_TEMP/release-notes.md"
         gh release create "v${VER}" \
-          --target "${GITHUB_REF_NAME}" \
+          --target "${{ steps.commit.outputs.release_sha }}" \
           --title "Tizen Workload ${VER} - .Net ${MAJOR_MINOR}" \
           --notes-file "$RUNNER_TEMP/release-notes.md" \
           --generate-notes

--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -37,42 +37,45 @@ jobs:
           --store-password-in-clear-text \
           --configfile workload/NuGet.config
 
-    - name: Bump TizenWorkloadVersion (global sequential, NuGet-derived)
+    # Resolve the version to release.
+    #
+    # Two properties matter here:
+    #  * A reference-only run (release_manifest=false) publishes no manifest, so it must be
+    #    completely NON-MUTATING - no bump, no commit, no tag.
+    #  * OLD == NEW is NOT necessarily an error. next-workload-version.py derives the next
+    #    version from what is published on NuGet, so if a previous run already bumped and
+    #    pushed but failed before publishing, the branch legitimately carries the intended
+    #    (still unpublished) version. That case must RESUME, not abort - otherwise a failed
+    #    release can never be retried.
+    - name: Resolve release version
       id: bump
       working-directory: ./workload
       run: |
-        set -e
+        set -euo pipefail
         OLD=$(grep -oP '(?<=<TizenWorkloadVersion>)[^<]+(?=</TizenWorkloadVersion>)' build/Versions.props)
         NEW=$(python3 scripts/next-workload-version.py)
         echo "Current: $OLD"
         echo "Next:    $NEW"
-        if [ "$OLD" = "$NEW" ]; then
-            echo "ERROR: computed next == current. NuGet already has this version published."
-            exit 1
+
+        if [ "${{ github.event.inputs.release_manifest }}" != "true" ]; then
+          echo "::notice ::Reference-only run: leaving TizenWorkloadVersion at $OLD (non-mutating)."
+          echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
+          echo "mutated=false" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
+
+        if [ "$OLD" = "$NEW" ]; then
+          # The branch already holds the version NuGet does not have yet: resume it.
+          echo "::notice ::Resuming release of $OLD (already set on this branch, not yet published)."
+          echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
+          echo "mutated=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         python3 scripts/next-workload-version.py --apply --verbose
         echo "workload_version=$NEW" >> "$GITHUB_OUTPUT"
+        echo "mutated=true" >> "$GITHUB_OUTPUT"
         echo "::notice ::Bumped TizenWorkloadVersion: $OLD -> $NEW"
-
-    # Persist the bump. Without this the tag created below points at a commit whose
-    # Versions.props still holds the PREVIOUS version, so the released sources do not
-    # correspond to the published package versions.
-    - name: Commit and push the version bump
-      run: |
-        set -e
-        BRANCH="${GITHUB_REF_NAME}"
-        VER="${{ steps.bump.outputs.workload_version }}"
-        if git diff --quiet -- workload/build/Versions.props; then
-          echo "::error::Versions.props was not modified by the bump step."
-          exit 1
-        fi
-        git config user.name  "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add workload/build/Versions.props
-        git commit -m "chore: bump TizenWorkloadVersion to ${VER}"
-        git push origin "HEAD:${BRANCH}"
-        echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      id: commit
 
     - name: Install Wix toolset
       run: sudo apt-get install -y wixl
@@ -124,6 +127,34 @@ jobs:
         echo "manifest_pkg=$MANIFEST_PKG" >> "$GITHUB_OUTPUT"
         echo "Staged packages:"; ls -1 "$STAGING"
 
+    # Persist the bump only AFTER the build succeeded and the expected artifacts were
+    # verified on disk. Committing earlier meant a later build failure left the branch
+    # already bumped, so the retry computed OLD == NEW and aborted - an unretryable release.
+    #
+    # Skipped when the resolve step did not mutate anything (reference-only run, or a resume
+    # of a version this branch already carries).
+    - name: Commit and push the version bump
+      id: commit
+      run: |
+        set -euo pipefail
+        BRANCH="${GITHUB_REF_NAME}"
+        VER="${{ steps.bump.outputs.workload_version }}"
+        if [ "${{ steps.bump.outputs.mutated }}" != "true" ]; then
+          echo "::notice ::No version mutation to persist; tagging existing HEAD."
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if git diff --quiet -- workload/build/Versions.props; then
+          echo "::error::Versions.props was not modified by the resolve step."
+          exit 1
+        fi
+        git config user.name  "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add workload/build/Versions.props
+        git commit -m "chore: bump TizenWorkloadVersion to ${VER}"
+        git push origin "HEAD:${BRANCH}"
+        echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
     - name: Push Manifest/SDK/Runtime packs
       if: ${{ github.event.inputs.release_manifest == 'true' }}
       run: |
@@ -159,6 +190,7 @@ jobs:
                       -t 3000 \
                       --skip-duplicate
 
+    # Idempotent: a resumed run whose tag already exists must not fail the whole release.
     - name: Create GitHub Release
       if: ${{ github.event.inputs.release_manifest == 'true' }}
       env:
@@ -187,6 +219,10 @@ jobs:
             [ -n "$v" ] && echo "- https://www.nuget.org/packages/Samsung.Tizen.Ref.API${api}/${v}"
           done
         } > "$RUNNER_TEMP/release-notes.md"
+        if gh release view "v${VER}" >/dev/null 2>&1; then
+          echo "::notice ::Release v${VER} already exists; skipping creation (resumed run)."
+          exit 0
+        fi
         gh release create "v${VER}" \
           --target "${{ steps.commit.outputs.release_sha }}" \
           --title "Tizen Workload ${VER} - .Net ${MAJOR_MINOR}" \

--- a/.github/workflows/release-workload.yml
+++ b/.github/workflows/release-workload.yml
@@ -21,6 +21,14 @@ permissions:
   contents: write
   packages: read
 
+# Only one release may be in flight at a time. Combined with the durable reservation ref
+# below, this prevents two runs (different branches/bands) from selecting the same global
+# workload version. `cancel-in-progress: false` so an in-flight release is never torn down
+# half-published.
+concurrency:
+  group: tizen-workload-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-22.04
@@ -37,21 +45,25 @@ jobs:
           --store-password-in-clear-text \
           --configfile workload/NuGet.config
 
-    # Resolve the version to release.
+    # Resolve, RESERVE and pin the release commit - before anything is built.
     #
-    # Publication is not atomic: the manifest, the remaining packs, the tag and the GitHub
-    # release are separate steps. If one fails partway, version V is PARTIALLY published -
-    # and because next-workload-version.py derives the next version from what exists on
-    # NuGet, it then answers V+1. Advancing at that point strands V forever with no tag,
-    # no release, and a missing pack set.
+    # Three problems are solved together here:
     #
-    # So the state of V is determined FIRST, and V is resumed unless it is provably complete:
-    #   unpublished  -> resume V if the branch already carries it, else bump
-    #   partial      -> ALWAYS resume V (never advance)
-    #   published    -> resume only to finish a missing tag/release, otherwise bump
+    #  * Artifact provenance. The Makefile embeds `git log -1` into every package, so
+    #    building before the version-bump commit made the packages carry a different SHA
+    #    than the tag - and a resumed run, building from a different commit, produced
+    #    packages that disagreed with the ones already published. The release commit is
+    #    therefore created FIRST and everything is built from that exact SHA.
     #
-    # A feed transport failure exits non-zero rather than being read as "unpublished".
-    - name: Resolve release version
+    #  * Concurrency. The global workload version is shared by every branch/band, so two
+    #    runs could pick the same V. Ownership is claimed by atomically creating a
+    #    reservation ref (`refs/tizen-release/v<V>`); git rejects a non-fast-forward
+    #    create, so exactly one run wins. A run that finds a foreign reservation aborts.
+    #
+    #  * Re-run drift. A re-run checks out the SHA of the original event and a fresh
+    #    dispatch checks out whatever the branch points at now, so the reserved SHA is
+    #    recorded and explicitly checked out below.
+    - name: Resolve and reserve release version
       id: bump
       working-directory: ./workload
       env:
@@ -66,54 +78,112 @@ jobs:
         BAND="$(compute_target_version_band "$SDK")"
         echo "band=$BAND" >> "$GITHUB_OUTPUT"
 
+        # A reference-only run publishes no manifest: fully non-mutating, no reservation.
         if [ "${{ github.event.inputs.release_manifest }}" != "true" ]; then
           echo "::notice ::Reference-only run: leaving TizenWorkloadVersion at $OLD (non-mutating)."
           echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
-          echo "mutated=false" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        # Publication state of the version the branch currently carries.
         STATE_OUT="$(python3 scripts/release-state.py --version "$OLD" --band "$BAND")"
         STATE="$(echo "$STATE_OUT" | sed -n 's/^state=//p')"
         MISSING="$(echo "$STATE_OUT" | sed -n 's/^missing=//p')"
         echo "State of $OLD: $STATE (missing: ${MISSING:-none})"
-        echo "resume_missing=$MISSING" >> "$GITHUB_OUTPUT"
 
-        # Has V already been tagged and released?
         if gh release view "v$OLD" >/dev/null 2>&1; then RELEASED=true; else RELEASED=false; fi
-        echo "Release v$OLD exists: $RELEASED"
 
+        RESUME=false
         if [ "$STATE" = "partial" ]; then
-          echo "::warning ::Version $OLD is partially published (missing: $MISSING). Resuming it instead of advancing."
-          echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
-          echo "mutated=false" >> "$GITHUB_OUTPUT"
+          echo "::warning ::Version $OLD is partially published (missing: $MISSING). Resuming."
+          RESUME=true
+        elif [ "$STATE" = "published" ] && [ "$RELEASED" != "true" ]; then
+          echo "::warning ::Version $OLD is published but untagged. Resuming to finish the release."
+          RESUME=true
+        elif [ "$STATE" = "unpublished" ] && git ls-remote --exit-code origin "refs/tizen-release/v$OLD" >/dev/null 2>&1; then
+          echo "::notice ::Version $OLD is already reserved on this repository. Resuming."
+          RESUME=true
+        fi
+
+        if [ "$RESUME" = "true" ]; then
+          VER="$OLD"
+          # The reservation records the commit the artifacts must be built from. Everything
+          # in a resumed run is rebuilt from that SHA so the retry cannot publish packages
+          # stamped with a different commit than the ones already on the feed.
+          RES_SHA="$(git ls-remote origin "refs/tizen-release/v$VER" | cut -f1)"
+          if [ -z "$RES_SHA" ]; then
+            echo "::error::Resuming $VER but no reservation ref exists. Refusing to guess the release commit."
+            exit 1
+          fi
+          echo "Reserved release commit: $RES_SHA"
+          echo "workload_version=$VER" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RES_SHA" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        if [ "$STATE" = "published" ] && [ "$RELEASED" != "true" ]; then
-          echo "::warning ::Version $OLD is fully published but has no release tag. Resuming to complete the tag/release."
-          echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
-          echo "mutated=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
+        # Fresh release: compute the candidate ONCE and write that exact value. Calling the
+        # script a second time with --apply would re-query the feed and could persist a
+        # different version if another release landed in between.
         NEW=$(python3 scripts/next-workload-version.py)
-        echo "Next: $NEW"
+        echo "Candidate: $NEW"
 
-        if [ "$STATE" = "unpublished" ] && [ "$OLD" = "$NEW" ]; then
-          # The branch already carries an unpublished version: resume it.
-          echo "::notice ::Resuming release of $OLD (set on this branch, nothing published yet)."
-          echo "workload_version=$OLD" >> "$GITHUB_OUTPUT"
-          echo "mutated=false" >> "$GITHUB_OUTPUT"
-          exit 0
+        if git ls-remote --exit-code origin "refs/tizen-release/v$NEW" >/dev/null 2>&1; then
+          echo "::error::Version $NEW is already reserved by another release. Aborting."
+          exit 1
         fi
 
-        # V is complete (published AND released): it is safe to advance.
-        python3 scripts/next-workload-version.py --apply --verbose
+        python3 scripts/next-workload-version.py --apply --set-version "$NEW" --verbose
+        cd ..
+        git config user.name  "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add workload/build/Versions.props
+        if git diff --cached --quiet; then
+          # OLD == NEW: the branch already carries the intended, still-unpublished version
+          # (a previous run bumped but never reserved). There is nothing to commit, so the
+          # current HEAD IS the release commit. Reserve it rather than failing.
+          echo "::notice ::TizenWorkloadVersion is already $NEW; reserving the current commit."
+        else
+          git commit -m "chore: bump TizenWorkloadVersion to ${NEW}"
+        fi
+        RELEASE_SHA="$(git rev-parse HEAD)"
+
+        # Claim ownership atomically. A non-fast-forward create is rejected, so if two runs
+        # race, exactly one wins and the loser aborts here rather than publishing.
+        if ! git push origin "$RELEASE_SHA:refs/tizen-release/v$NEW"; then
+          echo "::error::Failed to reserve $NEW (another release won the race). Aborting."
+          exit 1
+        fi
+        git push origin "HEAD:${GITHUB_REF_NAME}" || true
+
         echo "workload_version=$NEW" >> "$GITHUB_OUTPUT"
-        echo "mutated=true" >> "$GITHUB_OUTPUT"
-        echo "::notice ::Bumped TizenWorkloadVersion: $OLD -> $NEW"
+        echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+        echo "::notice ::Reserved and bumped TizenWorkloadVersion: $OLD -> $NEW at $RELEASE_SHA"
+
+    # Build from the RESERVED commit, never from whatever the branch or the re-run event
+    # happens to point at.
+    - name: Check out the reserved release commit
+      run: |
+        set -euo pipefail
+        SHA="${{ steps.bump.outputs.release_sha }}"
+        if [ -z "$SHA" ]; then
+          echo "::error::No release SHA was resolved."
+          exit 1
+        fi
+        git fetch origin "$SHA" --depth=1 2>/dev/null || git fetch origin
+        git checkout --detach "$SHA"
+        ACTUAL="$(git rev-parse HEAD)"
+        if [ "$ACTUAL" != "$SHA" ]; then
+          echo "::error::Checked out $ACTUAL but expected $SHA."
+          exit 1
+        fi
+        # The released sources must carry the released version.
+        VER="${{ steps.bump.outputs.workload_version }}"
+        ON_DISK=$(grep -oP '(?<=<TizenWorkloadVersion>)[^<]+(?=</TizenWorkloadVersion>)' workload/build/Versions.props)
+        if [ "${{ github.event.inputs.release_manifest }}" = "true" ] && [ "$ON_DISK" != "$VER" ]; then
+          echo "::error::Source drift: $SHA carries $ON_DISK but this release is $VER."
+          exit 1
+        fi
+        echo "Building from $SHA (TizenWorkloadVersion=$ON_DISK)"
 
     - name: Install Wix toolset
       run: sudo apt-get install -y wixl
@@ -165,35 +235,36 @@ jobs:
         echo "band=$BAND" >> "$GITHUB_OUTPUT"
         echo "manifest_id=Samsung.NET.Sdk.Tizen.Manifest-$BAND" >> "$GITHUB_OUTPUT"
         echo "manifest_pkg=$MANIFEST_PKG" >> "$GITHUB_OUTPUT"
-        echo "Staged packages:"; ls -1 "$STAGING"
-
-    # Persist the bump only AFTER the build succeeded and the expected artifacts were
-    # verified on disk. Committing earlier meant a later build failure left the branch
-    # already bumped, so the retry computed OLD == NEW and aborted - an unretryable release.
-    #
-    # Skipped when the resolve step did not mutate anything (reference-only run, or a resume
-    # of a version this branch already carries).
-    - name: Commit and push the version bump
-      id: commit
-      run: |
-        set -euo pipefail
-        BRANCH="${GITHUB_REF_NAME}"
-        VER="${{ steps.bump.outputs.workload_version }}"
-        if [ "${{ steps.bump.outputs.mutated }}" != "true" ]; then
-          echo "::notice ::No version mutation to persist; tagging existing HEAD."
-          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        if git diff --quiet -- workload/build/Versions.props; then
-          echo "::error::Versions.props was not modified by the resolve step."
+        # Every package embeds +sha.<short> (see Directory.Build.targets). They must all
+        # carry the SAME commit, and it must be the reserved release commit - otherwise a
+        # resumed run could publish a pack built from a different tree alongside packs
+        # already on the feed, and --skip-duplicate would happily preserve the mixture.
+        EXPECTED_SHA="$(git rev-parse --short "${{ steps.bump.outputs.release_sha }}")"
+        BAD=0
+        for pkg in "$STAGING"/*.nupkg; do
+          name="$(basename "$pkg")"
+          # Ref packs are versioned by TizenFX, not the workload version; skip them.
+          case "$name" in Samsung.Tizen.Ref.*) continue ;; esac
+          if [[ "$name" != *"+sha."* && "$name" != *"sha"* ]]; then
+            # Version metadata is stripped from the file name by NuGet; read the nuspec.
+            embedded="$(unzip -p "$pkg" '*.nuspec' 2>/dev/null | grep -oE '<version>[^<]+' | sed 's/<version>//' | head -1)"
+          else
+            embedded="$name"
+          fi
+          case "$embedded" in
+            *"+sha.$EXPECTED_SHA"*) ;;
+            *)
+              echo "::error::$name embeds '$embedded', expected +sha.$EXPECTED_SHA"
+              BAD=1
+              ;;
+          esac
+        done
+        if [ $BAD -ne 0 ]; then
+          echo "::error::Staged packages do not all originate from the reserved release commit."
           exit 1
         fi
-        git config user.name  "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add workload/build/Versions.props
-        git commit -m "chore: bump TizenWorkloadVersion to ${VER}"
-        git push origin "HEAD:${BRANCH}"
-        echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        echo "All staged packages carry +sha.$EXPECTED_SHA"
+        echo "Staged packages:"; ls -1 "$STAGING"
 
     # Publish every versioned pack. `--skip-duplicate` makes each push idempotent: NuGet
     # packages are immutable, so an id+version that already exists IS the intended artifact
@@ -293,7 +364,7 @@ jobs:
           exit 0
         fi
         gh release create "v${VER}" \
-          --target "${{ steps.commit.outputs.release_sha }}" \
+          --target "${{ steps.bump.outputs.release_sha }}" \
           --title "Tizen Workload ${VER} - .Net ${MAJOR_MINOR}" \
           --notes-file "$RUNNER_TEMP/release-notes.md" \
           --generate-notes

--- a/.github/workflows/validate-version-map.yml
+++ b/.github/workflows/validate-version-map.yml
@@ -10,7 +10,7 @@ name: Validate Version Map
 
 on:
   push:
-    branches: [ main, net7.0, net8.0, net9.0, net10.0 ]
+    branches: [ main, net7.0, net8.0, net9.0, net10.0, net11.0 ]
     paths:
       - 'workload/scripts/version-map.json'
       - 'workload/scripts/workload-install.sh'

--- a/workload/Config.mk
+++ b/workload/Config.mk
@@ -1,12 +1,13 @@
 # DOTNET_VERSION
--include $(TMPDIR)/dotnet-version.config
-$(TMPDIR)/dotnet-version.config: $(TOP)/build/Versions.props
-ifeq ($(DOTNET_VERSION), )
-	@mkdir -p $(TMPDIR)
-	@grep "<MicrosoftDotnetSdkInternalPackageVersion>" build/Versions.props | sed -e 's/<\/*MicrosoftDotnetSdkInternalPackageVersion>//g' -e 's/[ \t]*/DOTNET_VERSION=/' > $@
-else
-	@mkdir -p $(TMPDIR)
-	@echo "DOTNET_VERSION=$(DOTNET_VERSION)" > $@
+#
+# Resolved immediately from the caller or, when unset, from Versions.props.
+#
+# This used to be cached in $(TMPDIR)/dotnet-version.config with Versions.props as its only
+# prerequisite. Because the cache file was then newer than Versions.props, make never
+# regenerated it, so a DIFFERENT DOTNET_VERSION passed into an existing tree was ignored and
+# the previous band's value was reused - silently building/testing the wrong band.
+ifeq ($(strip $(DOTNET_VERSION)),)
+DOTNET_VERSION := $(shell grep -oE '<MicrosoftDotnetSdkInternalPackageVersion>[^<]+' $(TOP)/build/Versions.props | sed 's/.*>//')
 endif
 
 # TizenFX API versions per API level — auto-extracted from Versions.props (SSOT)
@@ -17,6 +18,13 @@ $(TMPDIR)/tizen-fx-api-versions.config: $(TOP)/build/Versions.props
 	  | sed -E 's/<TizenFXAPI([0-9]+)Version>/TizenFXAPI\1Version=/' > $@
 
 $(info DOTNET_VERSION is.. $(DOTNET_VERSION))
+
+# NOTE: do not add a parse-time guard for an empty DOTNET_VERSION here. The value arrives
+# via `-include $(TMPDIR)/dotnet-version.config`, and on make's first parse pass (before it
+# regenerates that file and restarts) DOTNET_VERSION is legitimately empty.
+# Pass DOTNET_VERSION through the environment or omit it entirely; an explicit empty
+# command-line override (make DOTNET_VERSION=) wins over the generated file and yields an
+# empty band.
 
 DOTNET_VERSION_BAND = $(firstword $(subst -, ,$(DOTNET_VERSION)))
 
@@ -30,31 +38,35 @@ endif
 MAJOR = $(word 1,$(VERSIONS))
 MINOR = $(word 2,$(VERSIONS))
 MICRO = $(word 3,$(VERSIONS))
-BAND := $(shell echo "${MICRO}" |  cut -c1)00
+# Feature band: the patch component rounded down to the nearest hundred (404 -> 400).
+BAND = $(shell echo "$(MICRO)" | cut -c1)00
 
 PRERELEASE = $(word 4,$(VERSIONS))
 PRERELEASE_VERSION = $(word 5,$(VERSIONS))
 
 # DOTNET_DESTDIR
 ifeq ($(DESTDIR),)
-	DOTNET_DESTDIR = $(OUTDIR)/dotnet
+	# Band-scoped: `make install DOTNET_VERSION=11...` in a tree that already built the
+	# .NET 10 band must bootstrap a separate SDK instead of reusing (and silently
+	# testing) the old one.
+	DOTNET_DESTDIR = $(OUTDIR)/dotnet-$(DOTNET_VERSION_BAND)
 else
 	DOTNET_DESTDIR = $(abspath $(DESTDIR))
 endif
 
 ifeq ($(MAJOR),6)
-	DOTNET6_MANIFESTS_DESTDIR := $(MAJOR).$(MINOR).$(BAND)
-	DOTNET_MANIFESTS_DESTDIR := $(DOTNET_DESTDIR)/sdk-manifests/$(DOTNET6_MANIFESTS_DESTDIR)/samsung.net.sdk.tizen
 	DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(BAND)
+	DOTNET6_MANIFESTS_DESTDIR := $(MAJOR).$(MINOR).$(BAND)
+	DOTNET_MANIFESTS_DESTDIR = $(DOTNET_DESTDIR)/sdk-manifests/$(DOTNET6_MANIFESTS_DESTDIR)/samsung.net.sdk.tizen
 else
 	ifneq ($(IS_PRERELEASE),)
 		ifneq ($(IS_RTM),)
-			DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(MICRO)-$(PRERELEASE)
+			DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(BAND)-$(PRERELEASE)
 		else
-			DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(MICRO)-$(PRERELEASE).$(PRERELEASE_VERSION)
+			DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(BAND)-$(PRERELEASE).$(PRERELEASE_VERSION)
 		endif
 	else
-		DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(MICRO)
+		DOTNET_VERSION_BAND := $(MAJOR).$(MINOR).$(BAND)
 	endif
 	DOTNET_MANIFESTS_DESTDIR = $(DOTNET_DESTDIR)/sdk-manifests/$(DOTNET_VERSION_BAND)/samsung.net.sdk.tizen
 endif

--- a/workload/Config.mk
+++ b/workload/Config.mk
@@ -46,10 +46,11 @@ PRERELEASE_VERSION = $(word 5,$(VERSIONS))
 
 # DOTNET_DESTDIR
 ifeq ($(DESTDIR),)
-	# Band-scoped: `make install DOTNET_VERSION=11...` in a tree that already built the
-	# .NET 10 band must bootstrap a separate SDK instead of reusing (and silently
-	# testing) the old one.
-	DOTNET_DESTDIR = $(OUTDIR)/dotnet-$(DOTNET_VERSION_BAND)
+	# Keyed by the FULL SDK version, not the feature band. Band-keying meant 10.0.100 and
+	# 10.0.101 (or two different previews of one band) shared a bootstrap directory, so the
+	# second request silently reused the first SDK and tested the wrong build. Manifest
+	# paths stay band-based below, which is what the SDK itself expects.
+	DOTNET_DESTDIR = $(OUTDIR)/dotnet-$(DOTNET_VERSION)
 else
 	DOTNET_DESTDIR = $(abspath $(DESTDIR))
 endif

--- a/workload/Makefile
+++ b/workload/Makefile
@@ -159,12 +159,16 @@ test-matrix-self-test:
 test-template-conditions:
 	@bash $(TOP)/scripts/test-template-conditions.sh
 
+.PHONY: test-package-fallback
+test-package-fallback:
+	@bash $(TOP)/scripts/test-package-fallback.sh
+
 .PHONY: test-install-failure
 test-install-failure:
 	@bash $(TOP)/scripts/test-install-failure.sh
 
 .PHONY: check
-check: validate-metadata test-matrix-self-test test-version-band test-template-conditions test-install-failure
+check: validate-metadata test-matrix-self-test test-version-band test-template-conditions test-package-fallback test-install-failure
 	@if command -v pwsh >/dev/null 2>&1; then \
 		pwsh $(TOP)/scripts/Generate-InstallScripts.ps1 -Check; \
 	else \

--- a/workload/Makefile
+++ b/workload/Makefile
@@ -59,7 +59,9 @@ $(eval $(call CreateNuGetPkgs,Samsung.NETCore.App.Runtime,$(TIZEN_WORKLOAD_VERSI
 packs: $(NUPKG_TARGETS)
 
 # Install workload to the dotnet sdk
-$(TMPDIR)/.stamp-install-workload: | $(DOTNET_MANIFESTS_DESTDIR)
+INSTALL_STAMP = $(TMPDIR)/.stamp-install-workload-$(DOTNET_VERSION_BAND)
+
+$(INSTALL_STAMP): | $(DOTNET_MANIFESTS_DESTDIR)
 	@cp -f \
 		$(TOP)/LICENSE \
 		$(TOP)/src/Samsung.NET.Sdk.Tizen/WorkloadManifest.targets \
@@ -70,14 +72,14 @@ $(TMPDIR)/.stamp-install-workload: | $(DOTNET_MANIFESTS_DESTDIR)
 	@touch $@
 
 .PHONY: install
-install: packs $(TMPDIR)/.stamp-install-workload
+install: packs $(INSTALL_STAMP)
 
 
 # Uninstall workload from the dotnet sdk
 .PHONY: uninstall
 uninstall:
 	@$(DOTNET) workload uninstall tizen
-	@rm -f $(TMPDIR)/.stamp-install-workload
+	@rm -f $(INSTALL_STAMP)
 
 # Create MSI windows installer
 define CreateMsi
@@ -99,9 +101,7 @@ $(TMPDIR)/msi: install
 	@cp -fr $(DOTNET_MANIFESTS_DESTDIR) $@/sdk-manifests/$(DOTNET_VERSION_BAND)
 	@mkdir -p $@/packs
 	@cp -fr $(DOTNET_DESTDIR)/packs/Samsung.Tizen.Sdk $@/packs
-	@cp -fr $(DOTNET_DESTDIR)/packs/Samsung.Tizen.Ref.API11 $@/packs
-	@cp -fr $(DOTNET_DESTDIR)/packs/Samsung.Tizen.Ref.API12 $@/packs
-	@cp -fr $(DOTNET_DESTDIR)/packs/Samsung.Tizen.Ref.API13 $@/packs
+	@cp -fr $(DOTNET_DESTDIR)/packs/Samsung.Tizen.Ref.API* $@/packs
 	@cp -fr $(DOTNET_DESTDIR)/packs/Samsung.NETCore.App.Runtime.* $@/packs
 	@mkdir -p $@/template-packs
 	@cp -f $(DOTNET_DESTDIR)/template-packs/samsung.tizen.templates.*.nupkg $@/template-packs
@@ -151,9 +151,42 @@ validate-metadata:
 test-version-band:
 	@bash $(TOP)/scripts/test-version-band.sh
 
+.PHONY: test-matrix-self-test
+test-matrix-self-test:
+	@bash $(TOP)/scripts/test-matrix.sh --self-test
+
+.PHONY: test-template-conditions
+test-template-conditions:
+	@bash $(TOP)/scripts/test-template-conditions.sh
+
+.PHONY: test-install-failure
+test-install-failure:
+	@bash $(TOP)/scripts/test-install-failure.sh
+
 .PHONY: check
-check: validate-metadata test-version-band
-	@pwsh $(TOP)/scripts/Generate-InstallScripts.ps1 -Check
+check: validate-metadata test-matrix-self-test test-version-band test-template-conditions test-install-failure
+	@if command -v pwsh >/dev/null 2>&1; then \
+		pwsh $(TOP)/scripts/Generate-InstallScripts.ps1 -Check; \
+	else \
+		echo "ERROR: pwsh not found. It is required to verify version-map drift and"; \
+		echo "       install-script integrity. Install PowerShell 7+ (https://aka.ms/powershell)"; \
+		echo "       or run: make check SKIP_PWSH_CHECKS=1 (leaves those checks unverified)."; \
+		[ -n "$(SKIP_PWSH_CHECKS)" ]; \
+	fi
+
+# Print the feature band Config.mk derives for DOTNET_VERSION. Used by
+# scripts/test-version-band.sh to prove the producer agrees with the installers.
+.PHONY: print-version-band
+print-version-band:
+	@echo $(DOTNET_VERSION_BAND)
+
+.PHONY: print-dotnet-destdir
+print-dotnet-destdir:
+	@echo $(DOTNET_DESTDIR)
+
+.PHONY: print-install-stamp
+print-install-stamp:
+	@echo $(INSTALL_STAMP)
 
 
 # Remove artifacts and temporary files

--- a/workload/Makefile
+++ b/workload/Makefile
@@ -141,6 +141,21 @@ test-matrix: install
 		bash $(TOP)/scripts/test-matrix.sh
 
 
+# Static checks that need no dotnet install: cross-file metadata consistency and
+# the SDK feature-band detection shared by both install scripts.
+.PHONY: validate-metadata
+validate-metadata:
+	@python3 $(TOP)/scripts/validate-workload-metadata.py
+
+.PHONY: test-version-band
+test-version-band:
+	@bash $(TOP)/scripts/test-version-band.sh
+
+.PHONY: check
+check: validate-metadata test-version-band
+	@pwsh $(TOP)/scripts/Generate-InstallScripts.ps1 -Check
+
+
 # Remove artifacts and temporary files
 clean:
 	@rm -fr $(OUTDIR)

--- a/workload/Makefile
+++ b/workload/Makefile
@@ -59,7 +59,7 @@ $(eval $(call CreateNuGetPkgs,Samsung.NETCore.App.Runtime,$(TIZEN_WORKLOAD_VERSI
 packs: $(NUPKG_TARGETS)
 
 # Install workload to the dotnet sdk
-INSTALL_STAMP = $(TMPDIR)/.stamp-install-workload-$(DOTNET_VERSION_BAND)
+INSTALL_STAMP = $(TMPDIR)/.stamp-install-workload-$(DOTNET_VERSION)
 
 $(INSTALL_STAMP): | $(DOTNET_MANIFESTS_DESTDIR)
 	@cp -f \

--- a/workload/Makefile
+++ b/workload/Makefile
@@ -163,12 +163,16 @@ test-template-conditions:
 test-package-fallback:
 	@bash $(TOP)/scripts/test-package-fallback.sh
 
+.PHONY: test-release-workflow
+test-release-workflow:
+	@bash $(TOP)/scripts/test-release-workflow.sh
+
 .PHONY: test-install-failure
 test-install-failure:
 	@bash $(TOP)/scripts/test-install-failure.sh
 
 .PHONY: check
-check: validate-metadata test-matrix-self-test test-version-band test-template-conditions test-package-fallback test-install-failure
+check: validate-metadata test-matrix-self-test test-version-band test-template-conditions test-package-fallback test-release-workflow test-install-failure
 	@if command -v pwsh >/dev/null 2>&1; then \
 		pwsh $(TOP)/scripts/Generate-InstallScripts.ps1 -Check; \
 	else \

--- a/workload/NuGet.config
+++ b/workload/NuGet.config
@@ -10,6 +10,7 @@
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
+    <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="github" value="https://nuget.pkg.github.com/Samsung/index.json" />
   </packageSources>
@@ -20,5 +21,10 @@
       <add key="ClearTextPassword" value="" />
     </github>
   </packageSourceCredentials> -->
-  <disabledPackageSources />
+  <disabledPackageSources>
+    <!-- Clear machine/user-level disable entries too; otherwise a developer who has
+         nuget.org disabled globally gets a confusing NU1101 even though the source is
+         listed above. Matches the "only the sources defined below are used" intent. -->
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/workload/README.md
+++ b/workload/README.md
@@ -1,6 +1,17 @@
 # Workload for Tizen .NET
 
-This is a build of Tizen workload for an early preview of Tizen in .NET 10.
-     
+This is a build of Tizen workload for Tizen in .NET 10, and for the .NET 11 preview SDK band.
+
+See [docs/net11.md](docs/net11.md) for the .NET 11 target framework / API-level mapping,
+how to build that band, and the external artifacts it is still blocked on.
+
+## Local checks
+
+```sh
+make check         # metadata consistency + version-band tests + install-script drift
+make test          # single-TFM smoke test (needs a bootstrapped SDK)
+make test-matrix   # full TFM matrix
+```
+
 ## Using IDEs
 Refer [here](https://github.com/dotnet/net6-mobile-samples#using-ides) to see the supporting status of an each IDE and how to manually enable workload.

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -58,9 +58,16 @@
   <!--
     .NET 11 is still in preview (latest SDK at time of writing: 11.0.100-preview.7.26381.103).
     Build a .NET 11 band manifest with:
-        make packs DOTNET_VERSION=11.0.100-preview.7.26381.103
+        make packs DOTNET_VERSION=$(DotNet11SdkVersion)
     which produces Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7.
+
+    DotNet11SdkVersion is the single source of truth for the .NET 11 SDK used by CI.
+    The workflows grep it out of this file, so bumping the preview here is enough.
   -->
+  <PropertyGroup>
+    <DotNet11SdkVersion>11.0.100-preview.7.26381.103</DotNet11SdkVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$(MicrosoftDotnetSdkInternalPackageVersion.StartsWith('11.0'))">
     <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26426.103</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>

--- a/workload/build/Versions.props
+++ b/workload/build/Versions.props
@@ -54,4 +54,14 @@
   <PropertyGroup Condition="$(MicrosoftDotnetSdkInternalPackageVersion.StartsWith('10.0'))">
     <MicrosoftDotNetBuildTasksFeedPackageVersion>10.0.0-beta.25531.102</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
+
+  <!--
+    .NET 11 is still in preview (latest SDK at time of writing: 11.0.100-preview.7.26381.103).
+    Build a .NET 11 band manifest with:
+        make packs DOTNET_VERSION=11.0.100-preview.7.26381.103
+    which produces Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7.
+  -->
+  <PropertyGroup Condition="$(MicrosoftDotnetSdkInternalPackageVersion.StartsWith('11.0'))">
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26426.103</MicrosoftDotNetBuildTasksFeedPackageVersion>
+  </PropertyGroup>
 </Project>

--- a/workload/docs/net11.md
+++ b/workload/docs/net11.md
@@ -74,7 +74,8 @@ eventual `11.0.100` GA need no further code change. This is asserted by
 | `test-matrix-self-test` | matrix row selection (an over-strict check silently builds nothing) |
 | `test-version-band` | SDK version → feature band across **both installers and Config.mk**, fallback band family, band isolation |
 | `test-template-conditions` | template platform detection across TFMs |
-| `test-install-failure` | installers exit non-zero on failure |
+| `test-package-fallback` | `PackageTargetFallback` compatibility filtering, incl. negative cross-platform/version cases |
+| `test-install-failure` | installers exit non-zero on failure; fallback resolves package **id**, no cross-SDK leakage |
 | `Generate-InstallScripts.ps1 -Check` | version-map drift **and** install-script integrity |
 
 `make check` requires `pwsh` for the last row. If it is unavailable the target fails with an
@@ -99,23 +100,53 @@ consequences worth knowing:
 Pass `DOTNET_VERSION` via the environment or omit it. An explicit empty command-line override
 (`make DOTNET_VERSION=`) beats the resolved value and yields an empty band.
 
-## Package asset resolution
-
-`PackageTargetFallback` in `Samsung.Tizen.Sdk.NuGet.targets` lists the package `lib/<tfm>/`
-folder names that `FixupNuGetReferences` prefers over a package's `netstandard2.x` assets. A
-combination missing from that list means a package shipping both `lib/netstandard2.0/` and
-`lib/<tfm>/` silently resolves to the **netstandard** assembly. It now covers the full
-(.NET major × Tizen platform) cross-product — including `net11.0-tizen11.0` — and check C8
-keeps it in sync with `KnownRuntimePack` × `TizenSdkSupportedTargetPlatformVersion`.
-
 ## Manifest fallback safety
 
 When a band's manifest is not published, the installers fall back to the cached version map.
-That fallback is now constrained to the **same .NET major.minor family**. The PowerShell
-installer previously took a fixed-length prefix (`$ManifestBaseName.Length + 2`), so
-`...Manifest-11.0.100-preview.7` was truncated to `...Manifest-1`, matched the 10.x entries and
-installed a **.NET 10 manifest into an 11.x band**. An 11.x request with no 11.x map entry now
-fails closed.
+Two properties are load-bearing:
+
+- **The resolved package ID travels with the version.** `getLatestVersion` /
+  `Get-LatestVersion` return `"<packageId>=<version>"`. Returning only a version made the
+  caller download that version under the *originally requested* — and unpublished — id: a
+  request for `...manifest-10.0.400` resolves to version `10.0.127`, which exists only under
+  `...manifest-10.0.300`, so the download 404'd. The manifest is still installed into the
+  **requested** band's directory; only the package fetched differs.
+- **The fallback is constrained to the same .NET major.minor family**, and the resolved id is
+  function-local. The PowerShell installer previously took a fixed-length prefix
+  (`$ManifestBaseName.Length + 2`), so `...Manifest-11.0.100-preview.7` was truncated to
+  `...Manifest-1`, matched the 10.x entries and installed a **.NET 10 manifest into an 11.x
+  band**. It also cached the resolved id in a script-level `$global:FallbackId` that was never
+  cleared, so an `-UpdateAllWorkloads` run could carry one SDK's fallback package into the
+  next SDK's install. Both are fixed and pinned by `scripts/test-install-failure.sh`.
+
+An 11.x request with no 11.x map entry fails closed.
+
+Note the installer must run under **bash 3.2** (macOS ships it and is a supported target, see
+`DOTNET_DEFAULT_PATH_MACOS`). The `${var,,}` lowercase expansion is bash 4+ and raised
+`bad substitution` there, leaving the version empty and silently skipping the fallback
+entirely; a portable `tr` is used instead, and an empty lookup response now takes the same
+fallback path as an explicit `BlobNotFound`.
+
+## Package asset resolution
+
+`PackageTargetFallback` in `Samsung.Tizen.Sdk.NuGet.targets` lists the package `lib/<tfm>/`
+folder names that `FixupNuGetReferences` prefers over a package's `netstandard2.x` assets.
+
+The task matches those directories **by name only** and performs no compatibility check of its
+own, so the list must be filtered to what the project can actually consume. An unfiltered
+cross-product lets a `net6.0-tizen8.0` build pick up `net6.0-tizen11.0` (newer platform) or
+`net11.0-tizen8.0` (newer .NET) assets. A candidate is emitted only when its .NET version and
+its Tizen platform version are both `<=` the project's, and candidates are appended
+highest-first so the best compatible match wins the task's first-wins selection.
+
+The filter is built from conditional **properties**, not filtered items: MSBuild evaluates all
+top-level properties before any items, so a property referencing `@(item)` at that level
+silently expands to nothing.
+
+Check C8 verifies the candidate list covers the full (.NET major × platform) cross-product
+*and* that every candidate carries a compatibility condition;
+`scripts/test-package-fallback.sh` pins the filtering itself with negative
+cross-platform/cross-version assertions.
 
 ## What changed in this repository
 
@@ -132,8 +163,10 @@ fails closed.
 | `scripts/test-version-band.sh` | new — asserts SDK-version → feature-band mapping for both installers |
 | `scripts/test-template-conditions.sh` | new — pins template platform detection across TFMs |
 | `scripts/test-install-failure.sh` | new — pins installer exit codes |
+| `scripts/test-package-fallback.sh` | new — pins `PackageTargetFallback` compatibility filtering |
 | `.github/workflows/build-matrix.yml` | .NET 11 leg, advisory off a `net11.0` branch and blocking on one |
 | `.github/workflows/build-workload.yml` | builds against `$(DotNet11SdkVersion)` on a `net11.0` branch |
+| `.github/workflows/release-workload.yml` | notes reuse the staging step's verified band / manifest id |
 
 ### Template platform detection
 
@@ -208,22 +241,39 @@ Observations from porting a real consumer (`Samsung/Tizen.UIExtensions`) onto th
   push target in `build-workload.yml`'s deploy job. Any documentation or template still pointing
   consumers at it for *restore* is dead; worth confirming whether the push target is still wanted.
 
-## `RuntimeList.xml` is not XML-parsed (investigated)
+## `RuntimeList.xml` and self-contained publishing
 
-`src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml` contains one `<FileList .../>` element per
-supported .NET version and therefore has multiple root elements, i.e. it is **not well-formed
-XML**. This is pre-existing and deliberate-by-accident: `Samsung.NETCore.App.Runtime.tizen` is a
-placeholder runtime pack (its only payload is `lib/net6.0-tizen/_._`), and the file is never
-parsed.
+`src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml` previously contained one
+`<FileList .../>` element per supported .NET version, i.e. **multiple root elements**, which
+is not well-formed XML.
 
-Verified against the .NET 11 SDK by replacing the installed pack's `RuntimeList.xml` with the
-literal text `<<< THIS IS NOT XML AT ALL &&& >>>` and rebuilding a `net11.0-tizen11.0` project
-**with an explicit `RuntimeIdentifier=tizen-x86`** — the path that resolves runtime pack assets,
-and the one .NET MAUI takes via `EnableImplicitRuntimeIdentifiers`. The build succeeded with
-0 errors.
+**This file is parsed.** `Microsoft.NET.Build.Tasks` contains the literal `RuntimeList.xml`
+alongside the runtime-pack manifest fields it reads (`Managed`, `Native`, `PgoData`,
+`Resources`, `AssemblyVersion`, `FileVersion`, `PublicKeyToken`), i.e.
+`ResolveRuntimePackAssets` reads it whenever runtime pack assets are resolved — notably for
+`SelfContained=true`. An earlier note in this file claimed it was never parsed; that claim was
+based on a framework-dependent RID build, which does not reach that task. **It was wrong and is
+retracted.**
 
-It is therefore left as-is: making it well-formed would require either a non-standard wrapper
-root or splitting the pack per .NET version, both of which carry more risk than the malformed
-file does while nothing reads it. Check C6 parses it with a line-oriented regex rather than an
-XML parser, matching how the file is actually produced and consumed. If a future SDK starts
-reading it, C6 and this note are the places to revisit.
+Both remediations are applied:
+
+1. **The file is now well-formed** — a single `<FileList>` root. The pack is a placeholder that
+   ships no runtime binaries (its only payload is `lib/net6.0-tizen/_._`), so the list is
+   legitimately empty.
+2. **Self-contained Tizen publishing is rejected up front** with `TIZENSDK001`, explaining that
+   Tizen applications run against the platform-provided runtime. Without it, the build failed
+   with the opaque `NETSDK1083: The specified RuntimeIdentifier 'tizen' is not recognized`.
+
+Verified on `11.0.100-preview.7.26381.103`: `dotnet build -p:SelfContained=true` on a
+`net11.0-tizen11.0` project now fails with `TIZENSDK001` and the actionable message.
+`SkipTizenSelfContainedCheck=true` bypasses the guard for anyone supplying a runtime by other
+means.
+
+**Scope note, stated precisely:** with the guard bypassed *and* the old malformed file restored,
+this configuration failed at `NETSDK1083` (RID resolution) *before* reaching
+`ResolveRuntimePackAssets`, so a raw `XmlException` could not be reproduced on this SDK. The
+malformed file was nevertheless a latent hazard on any path that does reach that task, and both
+fixes are correct regardless of which error surfaces first.
+
+Check C6 now parses the file with a real XML parser and asserts the `TIZENSDK001` guard exists;
+`test-matrix.sh` additionally asserts the runtime disposition end to end.

--- a/workload/docs/net11.md
+++ b/workload/docs/net11.md
@@ -45,9 +45,77 @@ make packs DOTNET_VERSION=11.0.100-preview.7.26381.103
 make test-matrix DOTNET_VERSION=11.0.100-preview.7.26381.103
 ```
 
+The exact SDK version CI uses lives in `build/Versions.props` as `<DotNet11SdkVersion>`.
+That property is the single source of truth: the workflows grep it, so bumping the preview
+there is enough. `validate-workload-metadata.py` check C7 fails if a workflow hardcodes a
+different `11.0.1xx-*` version.
+
 The band string is derived generically from `DOTNET_VERSION`, so `11.0.100-rc.1.*` and the
 eventual `11.0.100` GA need no further code change. This is asserted by
 [`scripts/test-version-band.sh`](../scripts/test-version-band.sh).
+
+## CI behaviour
+
+| Branch / PR target | .NET 10 matrix leg | .NET 11 matrix leg | `Build Workload` SDK |
+|---|---|---|---|
+| `main`, `net10.0` | blocking | advisory (`continue-on-error`) | Versions.props default (.NET 10) |
+| `net11.0` | blocking | **blocking** | **`$(DotNet11SdkVersion)`** |
+
+.NET 11 is advisory only while the branch ships a different band. On a `net11.0` branch
+.NET 11 *is* the product, so both the matrix leg and the workload build switch to it.
+
+## Local checks
+
+`make check` runs everything that needs no dotnet install or Tizen workload:
+
+| Target | What it pins |
+|---|---|
+| `validate-metadata` | C1–C8 cross-file consistency |
+| `test-matrix-self-test` | matrix row selection (an over-strict check silently builds nothing) |
+| `test-version-band` | SDK version → feature band across **both installers and Config.mk**, fallback band family, band isolation |
+| `test-template-conditions` | template platform detection across TFMs |
+| `test-install-failure` | installers exit non-zero on failure |
+| `Generate-InstallScripts.ps1 -Check` | version-map drift **and** install-script integrity |
+
+`make check` requires `pwsh` for the last row. If it is unavailable the target fails with an
+actionable message; `make check SKIP_PWSH_CHECKS=1` proceeds with those checks unverified.
+
+## Band isolation and feature-band rounding
+
+`DOTNET_VERSION` is resolved immediately in `Config.mk`, and `DOTNET_DESTDIR` plus the install
+stamp are scoped by band (`out/dotnet-<band>`, `.stamp-install-workload-<band>`). Two
+consequences worth knowing:
+
+- Building a different band in an existing tree bootstraps a separate SDK instead of reusing
+  the previous one. Previously `DOTNET_VERSION` was cached in `.tmp/dotnet-version.config`
+  whose only prerequisite was `Versions.props`; because the cache was newer, make never
+  regenerated it and a newly-passed `DOTNET_VERSION` was **ignored**, silently building and
+  testing the previous band.
+- Feature bands round the patch component down: `10.0.404` → `10.0.400`, `9.0.304` → `9.0.300`.
+  `Config.mk` previously did not round for stable non-6 versions, so it produced band
+  `10.0.404` while the installers looked for `10.0.400` — the manifest was installed where the
+  SDK would never look. `test-version-band.sh` now asserts producer/consumer agreement.
+
+Pass `DOTNET_VERSION` via the environment or omit it. An explicit empty command-line override
+(`make DOTNET_VERSION=`) beats the resolved value and yields an empty band.
+
+## Package asset resolution
+
+`PackageTargetFallback` in `Samsung.Tizen.Sdk.NuGet.targets` lists the package `lib/<tfm>/`
+folder names that `FixupNuGetReferences` prefers over a package's `netstandard2.x` assets. A
+combination missing from that list means a package shipping both `lib/netstandard2.0/` and
+`lib/<tfm>/` silently resolves to the **netstandard** assembly. It now covers the full
+(.NET major × Tizen platform) cross-product — including `net11.0-tizen11.0` — and check C8
+keeps it in sync with `KnownRuntimePack` × `TizenSdkSupportedTargetPlatformVersion`.
+
+## Manifest fallback safety
+
+When a band's manifest is not published, the installers fall back to the cached version map.
+That fallback is now constrained to the **same .NET major.minor family**. The PowerShell
+installer previously took a fixed-length prefix (`$ManifestBaseName.Length + 2`), so
+`...Manifest-11.0.100-preview.7` was truncated to `...Manifest-1`, matched the 10.x entries and
+installed a **.NET 10 manifest into an 11.x band**. An 11.x request with no 11.x map entry now
+fails closed.
 
 ## What changed in this repository
 
@@ -58,10 +126,25 @@ eventual `11.0.100` GA need no further code change. This is asserted by
 | `src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets` | added the `net11.0` `KnownRuntimePack` |
 | `src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml` | added the `.NET Runtime 11` `FileList` row |
 | `src/Samsung.Tizen.Templates/.../template.json` | added the `net11.0` framework choice (default stays `net10.0`) |
-| `scripts/test-matrix.sh` | added `net11.0-tizen11.0` / `net11.0-tizen10.0` rows, skipped when no 11.x SDK is present |
-| `scripts/validate-workload-metadata.py` | new checks C5/C6 tying template + matrix TFMs to `KnownRuntimePack` and `RuntimeList.xml` |
+| `src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj` | Material referenced conditionally; platform version parsed from the TFM, not `$(TargetPlatformVersion)` (see below) |
+| `scripts/test-matrix.sh` | added `net11.0-*` rows; rows are skipped only when newer than the installed SDK; `--self-test` mode |
+| `scripts/validate-workload-metadata.py` | new checks C5/C6/C7 |
 | `scripts/test-version-band.sh` | new — asserts SDK-version → feature-band mapping for both installers |
-| `.github/workflows/build-matrix.yml` | added a non-blocking .NET 11 preview matrix leg |
+| `scripts/test-template-conditions.sh` | new — pins template platform detection across TFMs |
+| `scripts/test-install-failure.sh` | new — pins installer exit codes |
+| `.github/workflows/build-matrix.yml` | .NET 11 leg, advisory off a `net11.0` branch and blocking on one |
+| `.github/workflows/build-workload.yml` | builds against `$(DotNet11SdkVersion)` on a `net11.0` branch |
+
+### Template platform detection
+
+`PackageReference` items are evaluated with the project body, which runs **before** the .NET
+SDK infers `$(TargetPlatformVersion)` from the TFM. Reading that property in the body yields an
+empty string, so a naive implementation falls back to the default and pulls an incompatible
+`Tizen.UI.Components.Material` into e.g. `net11.0-tizen9.0` while never raising `TIZENTMPL001`.
+The template therefore parses the platform version out of `$(TargetFramework)` directly, and
+re-checks the authoritative `$(TargetPlatformVersion)` inside a target where it is available.
+`scripts/test-template-conditions.sh` extracts the shipped `PropertyGroup` and pins the
+behaviour across 13 TFMs.
 
 `version-map.json` is deliberately **not** updated. That table is a fallback cache of *already
 published* manifest versions, consulted only when the NuGet lookup fails. Adding an entry for a
@@ -111,3 +194,36 @@ they are not faked here.
   target platform is below `tizen10.0`.
 - **Expected artifact:** a release with `lib/` assets for the lower platform bands, or a separate
   non-Material template family for them.
+
+## Notes for release notes
+Observations from porting a real consumer (`Samsung/Tizen.UIExtensions`) onto this band:
+
+- **`net6.0-tizen7.0` is no longer reproducible.** `Samsung.Tizen.Sdk` dropped `7.0` from
+  `TizenSdkSupportedTargetPlatformVersion` (now `8.0`/`9.0`/`10.0`/`10.1`/`11.0`), so packages
+  that historically shipped a `net6.0-tizen7.0` asset cannot rebuild one.
+- **Unversioned `net6.0-tizen` now resolves to platform 10.0** (`_DefaultTargetPlatformVersion`),
+  i.e. TizenFX API 13, where all of ElmSharp and `Tizen.NUI.Window.Instance` are `[Obsolete]`.
+  Consumers building that TFM with `TreatWarningsAsErrors` will break. Use a versioned TFM.
+- **`tizen.myget.org` returns HTTP 401 to anonymous clients.** The feed is still referenced as a
+  push target in `build-workload.yml`'s deploy job. Any documentation or template still pointing
+  consumers at it for *restore* is dead; worth confirming whether the push target is still wanted.
+
+## `RuntimeList.xml` is not XML-parsed (investigated)
+
+`src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml` contains one `<FileList .../>` element per
+supported .NET version and therefore has multiple root elements, i.e. it is **not well-formed
+XML**. This is pre-existing and deliberate-by-accident: `Samsung.NETCore.App.Runtime.tizen` is a
+placeholder runtime pack (its only payload is `lib/net6.0-tizen/_._`), and the file is never
+parsed.
+
+Verified against the .NET 11 SDK by replacing the installed pack's `RuntimeList.xml` with the
+literal text `<<< THIS IS NOT XML AT ALL &&& >>>` and rebuilding a `net11.0-tizen11.0` project
+**with an explicit `RuntimeIdentifier=tizen-x86`** — the path that resolves runtime pack assets,
+and the one .NET MAUI takes via `EnableImplicitRuntimeIdentifiers`. The build succeeded with
+0 errors.
+
+It is therefore left as-is: making it well-formed would require either a non-standard wrapper
+root or splitting the pack per .NET version, both of which carry more risk than the malformed
+file does while nothing reads it. Check C6 parses it with a line-oriented regex rather than an
+XML parser, matching how the file is actually produced and consumed. If a future SDK starts
+reading it, C6 and this note are the places to revisit.

--- a/workload/docs/net11.md
+++ b/workload/docs/net11.md
@@ -74,8 +74,9 @@ eventual `11.0.100` GA need no further code change. This is asserted by
 | `test-matrix-self-test` | matrix row selection (an over-strict check silently builds nothing) |
 | `test-version-band` | SDK version → feature band across **both installers and Config.mk**, fallback band family, band isolation |
 | `test-template-conditions` | template platform detection across TFMs |
-| `test-package-fallback` | `PackageTargetFallback` compatibility filtering, incl. negative cross-platform/version cases |
-| `test-install-failure` | installers exit non-zero on failure; fallback resolves package **id**, no cross-SDK leakage |
+| `test-package-fallback` | fallback filtering, plus selection priority / atomicity in both directory-creation orders |
+| `test-release-workflow` | release ordering, retryability, non-mutating reference-only runs |
+| `test-install-failure` | installer exit codes, fallback package **id**, SDK-pin verification, empty/transport responses |
 | `Generate-InstallScripts.ps1 -Check` | version-map drift **and** install-script integrity |
 
 `make check` requires `pwsh` for the last row. If it is unavailable the target fails with an
@@ -121,6 +122,18 @@ Two properties are load-bearing:
 
 An 11.x request with no 11.x map entry fails closed.
 
+The resolved version is validated before use. An empty or all-blank `versions[]` from the feed
+is rejected rather than returned as a truthy `"<id>="`: the NuGet v2 package endpoint serves the
+**latest** version when given a versionless URL, so an empty version would silently install an
+arbitrary package. Both installers fall through to the version map and then fail closed.
+
+The SDK pin is verified before anything is installed. `install_tizenworkload` is invoked under
+`if !`, which disables `errexit` for everything it calls, so an unchecked
+`dotnet new globaljson` previously let the install proceed against whatever SDK `PATH` resolved.
+The pin now uses the dotnet under test, its exit status is checked, and the **effective**
+`dotnet --version` and feature band are re-verified against the requested ones before any pack
+is installed.
+
 Note the installer must run under **bash 3.2** (macOS ships it and is a supported target, see
 `DOTNET_DEFAULT_PATH_MACOS`). The `${var,,}` lowercase expansion is bash 4+ and raised
 `bad substitution` there, leaving the version empty and silently skipping the fallback
@@ -142,6 +155,15 @@ highest-first so the best compatible match wins the task's first-wins selection.
 The filter is built from conditional **properties**, not filtered items: MSBuild evaluates all
 top-level properties before any items, so a property referencing `@(item)` at that level
 silently expands to nothing.
+
+`PackageTargetFallback` is an **ordered preference list**, and `FixupNuGetReferences` honours
+that order: it ranks candidates by their position in the list and selects exactly **one**
+fallback TFM per package, taking every substituted assembly from that single directory. It
+previously collected all matching directories into an unordered `HashSet` populated in
+filesystem-enumeration order and then took assemblies first-wins across them, which could both
+ignore the declared priority and mix assemblies from different TFMs within one package.
+`scripts/test-package-fallback.sh` builds the candidate directories in **both** creation orders
+so the assertion does not depend on how a particular filesystem enumerates.
 
 Check C8 verifies the candidate list covers the full (.NET major × platform) cross-product
 *and* that every candidate carries a compatibility condition;
@@ -277,3 +299,24 @@ fixes are correct regardless of which error surfaces first.
 
 Check C6 now parses the file with a real XML parser and asserts the `TIZENSDK001` guard exists;
 `test-matrix.sh` additionally asserts the runtime disposition end to end.
+
+## Release retryability
+
+The release workflow is ordered so a failure is always retryable:
+
+1. resolve the version (no mutation yet),
+2. clean, build, and **verify** the expected artifacts on disk,
+3. only then commit and push the version bump,
+4. push packages from the verified staging directory,
+5. create the tag, targeting the commit that carries the released `Versions.props`.
+
+Committing the bump *before* the build meant a later failure left the branch already bumped, so
+the retry computed `OLD == NEW` and aborted — an unretryable release. `OLD == NEW` is therefore
+no longer an error: `next-workload-version.py` derives the next version from what is published
+on NuGet, so when the branch already carries the intended still-unpublished version the run
+**resumes** it. Re-creating an existing tag is a no-op.
+
+A reference-only run (`release_manifest=false`) publishes no manifest and is completely
+non-mutating: no bump, no commit, no tag.
+
+`scripts/test-release-workflow.sh` pins all of the above.

--- a/workload/docs/net11.md
+++ b/workload/docs/net11.md
@@ -1,0 +1,113 @@
+# .NET 11 support
+
+This branch builds the `tizen` workload for the .NET 11 SDK band in addition to .NET 10.
+
+At the time of writing .NET 11 is in **preview**: the newest SDK is
+`11.0.100-preview.7.26381.103` (released 2026-08-11). Everything below therefore describes a
+band that is real and buildable, but whose manifest package has **not been published to
+nuget.org yet**.
+
+## TFM and API mapping
+
+The primary target framework is **`net11.0-tizen11.0`**.
+
+| Tizen platform version | TizenFX API level | Targeting (ref) pack | Pack version |
+|---|---|---|---|
+| `tizen8.0`  | 11 | `Samsung.Tizen.Ref.API11` | `$(TizenFXAPI11Version)` |
+| `tizen9.0`  | 12 | `Samsung.Tizen.Ref.API12` | `$(TizenFXAPI12Version)` |
+| `tizen10.0` | 13 | `Samsung.Tizen.Ref.API13` | `$(TizenFXAPI13Version)` |
+| `tizen10.1` | 14 | `Samsung.Tizen.Ref.API14` | `$(TizenFXAPI14Version)` |
+| **`tizen11.0`** | **15** | **`Samsung.Tizen.Ref.API15`** | `$(TizenFXAPI15Version)` |
+
+The .NET version axis and the Tizen platform axis are independent, so `net11.0` combines with
+every platform version above — `net11.0-tizen8.0` … `net11.0-tizen11.0` are all valid. The
+`tizen-manifest.xml` `api-version` attribute must match the platform version
+(`tizen11.0` → `api-version="11"`, `tizen10.1` → `10.1`, `tizen10.0` → `10`).
+
+**No new reference pack is required for .NET 11.** Ref packs ship reference assemblies under
+`ref/net8.0/` and are resolved by explicit `<File Path="…"/>` entries in `data/FrameworkList.xml`,
+so they are independent of the consuming project's .NET version. `Samsung.Tizen.Ref.API16` does
+not exist and is not needed.
+
+Use versioned TFMs. The unversioned `net11.0-tizen` form is still accepted as project input but
+resolves to `_DefaultTargetPlatformVersion` (`10.0`), which is rarely what a caller wants.
+
+## Building the .NET 11 band
+
+`DOTNET_VERSION` selects the SDK band; it defaults to
+`MicrosoftDotnetSdkInternalPackageVersion` in `build/Versions.props` (currently the .NET 10 band).
+
+```sh
+# Produce the packs, including Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7
+make packs DOTNET_VERSION=11.0.100-preview.7.26381.103
+
+# Install into the locally bootstrapped SDK and run the full TFM matrix
+make test-matrix DOTNET_VERSION=11.0.100-preview.7.26381.103
+```
+
+The band string is derived generically from `DOTNET_VERSION`, so `11.0.100-rc.1.*` and the
+eventual `11.0.100` GA need no further code change. This is asserted by
+[`scripts/test-version-band.sh`](../scripts/test-version-band.sh).
+
+## What changed in this repository
+
+| File | Change |
+|---|---|
+| `build/Versions.props` | `MicrosoftDotNetBuildTasksFeedPackageVersion` = `11.0.0-beta.26426.103` when building an `11.0` band |
+| `NuGet.config` | added the `dotnet11` package source |
+| `src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets` | added the `net11.0` `KnownRuntimePack` |
+| `src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml` | added the `.NET Runtime 11` `FileList` row |
+| `src/Samsung.Tizen.Templates/.../template.json` | added the `net11.0` framework choice (default stays `net10.0`) |
+| `scripts/test-matrix.sh` | added `net11.0-tizen11.0` / `net11.0-tizen10.0` rows, skipped when no 11.x SDK is present |
+| `scripts/validate-workload-metadata.py` | new checks C5/C6 tying template + matrix TFMs to `KnownRuntimePack` and `RuntimeList.xml` |
+| `scripts/test-version-band.sh` | new — asserts SDK-version → feature-band mapping for both installers |
+| `.github/workflows/build-matrix.yml` | added a non-blocking .NET 11 preview matrix leg |
+
+`version-map.json` is deliberately **not** updated. That table is a fallback cache of *already
+published* manifest versions, consulted only when the NuGet lookup fails. Adding an entry for a
+band that has never been released would make `workload-install.sh` download a 404. The
+`11.0.100-preview.7` entry should be added in a follow-up commit *after* the first release, the
+same way `10.0.300` was.
+
+## External blockers
+
+These artifacts are owned by other repositories. Nothing in Samsung/Tizen.NET can fix them, and
+they are not faked here.
+
+### 1. `Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7` is unpublished
+
+- **Owner:** Samsung/Tizen.NET maintainers (this repo's `Release Workload` workflow).
+- **Action:** run `Release Workload` with `net_sdk_version = 11.0.100-preview.7.26381.103`.
+- **Until then:** `workload-install.sh` on an 11.x SDK finds no manifest. Local development works
+  via `make install DOTNET_VERSION=11.0.100-preview.7.26381.103`, which installs into the
+  bootstrapped SDK under `workload/out/dotnet`.
+
+### 2. `Tizen.UIExtensions.NUI` has no modern assets
+
+- **Owner:** [Samsung/Tizen.UIExtensions](https://github.com/Samsung/Tizen.UIExtensions).
+- **Published state:** `0.9.2` ships `lib/net6.0-tizen7.0/` and `lib/tizen10.0/`. Source on `main`
+  targets `<TargetFrameworks>tizen10.0;net6.0-tizen</TargetFrameworks>` against
+  `Tizen.NET 10.0.0.17508` (API level 10).
+- **Note:** NuGet TFM compatibility is *not* the problem — `net6.0-tizen7.0` is consumable from
+  `net11.0-tizen11.0`. The blocker is the dependency group, which pins
+  `Microsoft.Maui.Graphics` / `Microsoft.Maui.Graphics.Skia` `6.0.300-rc.3.1336` and
+  `SkiaSharp.Views 2.88.6`, dragging .NET 6-era MAUI Graphics into any modern MAUI build.
+- **Expected artifact:** a `Tizen.UIExtensions.NUI` release with a `lib/net11.0-tizen11.0/` folder
+  built against `Samsung.Tizen.Ref.API15` and a refreshed `Microsoft.Maui.Graphics*` dependency.
+- **API risk, measured:** all types .NET MAUI's Tizen backend needs are present in API 15. Between
+  API 11 and API 15, `Tizen.NUI.ScrollView`, `Tizen.NUI.ItemView` (and the `Item*`/`Ruler*`
+  families), `Tizen.NUI.Components.Title`, `Tizen.NUI.Adaptor`, `Tizen.NUI.AutofillContainer`,
+  `Tizen.NUI.Accessibility.AccessibilityManager`, the `CubeTransition*` effects and the entire
+  `Tizen.NUI.Wearable` namespace were removed. Ports should use
+  `Tizen.NUI.Components.ScrollableBase`, which is retained.
+
+### 3. `Tizen.UI.Components.Material` is platform-gated
+
+- **Owner:** TizenAPI / Samsung (package `Tizen.UI.Components.Material`).
+- **Published state:** `1.0.0-rc.8` ships **only** `lib/net8.0-tizen10.0/`; never went GA.
+- **Effect:** consumable from `-tizen10.0`, `-tizen10.1` and `-tizen11.0`, but not from
+  `-tizen8.0` / `-tizen9.0`. The `dotnet new tizen` template now references it conditionally and
+  raises `TIZENTMPL001` with an actionable message instead of an opaque restore failure when the
+  target platform is below `tizen10.0`.
+- **Expected artifact:** a release with `lib/` assets for the lower platform bands, or a separate
+  non-Material template family for them.

--- a/workload/docs/net11.md
+++ b/workload/docs/net11.md
@@ -308,19 +308,43 @@ Check C6 now parses the file with a real XML parser and asserts the `TIZENSDK001
 
 ## Release retryability
 
-The release workflow is ordered so a failure is always retryable:
+The release workflow **reserves first, then builds**:
 
-1. resolve the version (no mutation yet),
-2. clean, build, and **verify** the expected artifacts on disk,
-3. only then commit and push the version bump,
-4. push packages from the verified staging directory,
-5. create the tag, targeting the commit that carries the released `Versions.props`.
+1. resolve the version (no mutation yet) and pin it as one immutable candidate,
+2. create the release commit and **reserve** it globally,
+3. check out the reserved SHA explicitly and build from *that* commit only,
+4. verify every staged package carries the reserved SHA,
+5. push packages from the verified staging directory,
+6. create the tag, targeting the reserved SHA.
 
-Committing the bump *before* the build meant a later failure left the branch already bumped, so
-the retry computed `OLD == NEW` and aborted — an unretryable release. `OLD == NEW` is therefore
-no longer an error: `next-workload-version.py` derives the next version from what is published
-on NuGet, so when the branch already carries the intended still-unpublished version the run
-**resumes** it. Re-creating an existing tag is a no-op.
+> **This deliberately reverses the earlier "commit only after a verified build" ordering.**
+> That ordering was adopted to keep a failed release retryable, but it cannot hold once a
+> resume has to rebuild: the Makefile embeds the current Git SHA in every package, so an
+> initial run and its retry produced packages built from *different* commits, and
+> skip-duplicate happily preserved that mixed set under a tag pointing at only one of them.
+> Retryability now comes from the **reservation**, not from deferring the commit — the
+> reserved SHA is the single source of truth that both the first attempt and every retry
+> build from, so provenance is identical by construction.
+
+`OLD == NEW` is not an error. `next-workload-version.py` derives the next version from what is
+published on NuGet, so when the branch already carries the intended still-unpublished version
+the run resumes it; there is simply nothing to commit, and the current HEAD *is* the release
+commit, so it is reserved as-is. Re-creating an existing tag is a no-op.
+
+### Reservation and concurrency
+
+Two branches or bands releasing at once could previously select the same next version, both
+push, and let skip-duplicate silently accept one owner's packs while the other's were dropped.
+Ownership is now explicit:
+
+* the job takes a repository-wide `concurrency` group (`cancel-in-progress: false`),
+* it claims `refs/tizen-release/v<version>` with an atomic create — losing the race aborts,
+* a retry must **prove** it owns the reservation (the ref must point at its release SHA);
+  a foreign reservation aborts rather than publishing over someone else's version.
+
+Because `workflow_dispatch` re-runs check out the *original* event SHA rather than the pushed
+bump commit, every downstream step checks out the reserved SHA explicitly and rejects source
+drift instead of silently building the wrong tree.
 
 A reference-only run (`release_manifest=false`) publishes no manifest and is completely
 non-mutating: no bump, no commit, no tag.
@@ -358,3 +382,39 @@ network blip would advance the version and strand the release it was meant to pr
 
 `scripts/test-release-workflow.sh` pins all of the above, including failure injection at each
 publication step.
+
+
+## Installer band selection
+
+`workload-install.sh` and `workload-install.ps1` must behave identically; `test-version-band.sh`
+extracts the real logic from both (never a hand-copy) and compares them case by case.
+
+**Closest band at or below the request.** When a manifest for the active band is unavailable the
+installer falls back — but it must fall back *downwards*. Selecting `10.0.300` for a `10.0.200`
+request skips the published `10.0.200` manifest entirely and installs a newer feature band's
+metadata. Both installers now order candidates with a numeric band sort key and choose the
+closest compatible band `<= ` the request, and the fallback returns the resolved **package ID
+and version together** — resolving only a version left the download using the original,
+unavailable manifest ID.
+
+**Explicit vs. derived target band.** `-t` / `-Tizen` is documented as supporting cross-band
+installation, so the "target band must equal the active SDK band" rule applies **only** to an
+auto-derived band. An explicitly requested band is honoured, and all inputs are validated
+*before* anything is written.
+
+**SDK pinning is validated before any mutation.** `install_tizenworkload` is invoked under `if !`,
+which suppresses `errexit` for everything it calls, so an unchecked `dotnet new globaljson` could
+fail and let the install proceed against the wrong SDK. Every pin command is now checked
+explicitly and the effective `dotnet --version` is re-read and compared before download.
+
+**Atomic manifest replacement.** The payload is staged and verified in a temporary directory
+alongside the destination, then swapped in atomically, with rollback of the previous manifest on
+any failure. Previously a partial copy could destroy a working manifest, and the leftover
+directory made a subsequent existence check pass.
+
+**SDK bootstrap is keyed by full SDK version.** `DOTNET_DESTDIR` and the install stamp include
+the exact SDK version (`10.0.100` vs `10.0.101` vs a preview build), so `make install` no longer
+reuses a stale SDK that merely shares a feature band. Manifest paths remain band-based.
+
+Shell tests run under stock macOS Bash 3.2 (no `${var,,}`), and cover spaced paths, empty and
+transport-failed version queries, and mixed-band `UpdateAllWorkloads`.

--- a/workload/docs/net11.md
+++ b/workload/docs/net11.md
@@ -288,14 +288,38 @@ Both remediations are applied:
 1. **The file is now well-formed** — a single `<FileList>` root. The pack is a placeholder that
    ships no runtime binaries (its only payload is `lib/net6.0-tizen/_._`), so the list is
    legitimately empty.
-2. **Self-contained Tizen publishing is rejected up front** with `TIZENSDK001`, explaining that
-   Tizen applications run against the platform-provided runtime. Without it, the build failed
-   with the opaque `NETSDK1083: The specified RuntimeIdentifier 'tizen' is not recognized`.
+2. **Explicitly requested self-contained Tizen publishing is rejected up front** with
+   `TIZENSDK001`, explaining that Tizen applications run against the platform-provided runtime.
+   Without it, the build failed with the opaque `NETSDK1083: The specified RuntimeIdentifier
+   'tizen' is not recognized`.
 
-Verified on `11.0.100-preview.7.26381.103`: `dotnet build -p:SelfContained=true` on a
-`net11.0-tizen11.0` project now fails with `TIZENSDK001` and the actionable message.
+The guard (`_TizenErrorOnSelfContained` in `Samsung.Tizen.Sdk.targets`) gates on the SDK's
+`_SelfContainedWasSpecified`, **not** on the final `$(SelfContained)` value, and this distinction
+is load-bearing. The .NET SDK (`Microsoft.NET.RuntimeIdentifierInference.targets`) still *infers*
+`SelfContained=true` from a present `RuntimeIdentifier` on pre-8.0 TFMs, and the Tizen SDK
+supplies an implicit RID (`tizen-x86`) for MAUI apps. Gating on the inferred `$(SelfContained)`
+therefore mis-classified an ordinary **framework-dependent** `net6.0-tizen` / `net7.0-tizen` build
+— exactly what every existing .NET MAUI Tizen consumer does — as self-contained and broke it.
+`_SelfContainedWasSpecified` is set by the SDK only when self-contained was *explicitly* requested
+(`-p:SelfContained=true`, or `PublishSelfContained=true` during publish, which the SDK copies onto
+`SelfContained` before computing `_SelfContainedWasSpecified`), so the guard now fires on explicit
+requests only.
+
+Verified empirically on `11.0.100-preview.7.26381.103` (`dotnet msbuild -nodereuse:false`,
+`OutputType=Exe`, implicit RID `tizen-x86`):
+
+| Build | inferred `SelfContained` | `_SelfContainedWasSpecified` | TIZENSDK001 |
+| --- | --- | --- | --- |
+| `net6.0-tizen`, framework-dependent | `true` | *(empty)* | **no** (was wrongly yes) |
+| `net7.0-tizen`, framework-dependent | `true` | *(empty)* | **no** (was wrongly yes) |
+| `net8.0`–`net11.0-tizen*`, framework-dependent | `false` | *(empty)* | no |
+| any `-tizen*` with `-p:SelfContained=true` | `true` | `true` | **yes** |
+| any `-tizen*` publish `-p:PublishSelfContained=true` | `true` | `true` | **yes** |
+
 `SkipTizenSelfContainedCheck=true` bypasses the guard for anyone supplying a runtime by other
-means.
+means. These behaviours are locked down by `test-template-conditions.sh`, which extracts the real
+guard `<Target>` from the shipped targets and asserts each row above without needing the Tizen
+workload.
 
 **Scope note, stated precisely:** with the guard bypassed *and* the old malformed file restored,
 this configuration failed at `NETSDK1083` (RID resolution) *before* reaching
@@ -330,6 +354,31 @@ The release workflow **reserves first, then builds**:
 published on NuGet, so when the branch already carries the intended still-unpublished version
 the run resumes it; there is simply nothing to commit, and the current HEAD *is* the release
 commit, so it is reserved as-is. Re-creating an existing tag is a no-op.
+
+### What a reservation records
+
+A reservation used to be nothing but a ref pointing at a commit. That answers *"is this
+version taken"* but not *"is this run allowed to continue it"*, and both gaps were real:
+
+* **Re-runs could never resume their own release.** `Re-run jobs` checks out the SHA of the
+  *original* event — the commit *before* the version bump — so the version read from
+  `Versions.props` was the previous, already-released one. The re-run concluded there was
+  nothing to resume, recomputed the same candidate, found its own reservation ref and
+  aborted as though a stranger held it. An interrupted release was permanently unfinishable.
+* **Nothing tied a reservation to the inputs it was made for**, so re-dispatching with a
+  different `net_sdk_version` would adopt a reservation created for another band.
+
+`refs/tizen-release/v<V>` is therefore an *annotated tag object* whose message carries the
+complete release input set — version, reserved SHA, SDK, band, manifest id, package set and
+branch (`scripts/release-reservation.py`). Resume is decided by **enumerating** those refs
+and matching them against the current run's inputs; the checked-out SHA is no longer used
+for that decision at all. A reservation that does not match every input is skipped, and one
+that predates the payload format cannot be validated and so is refused rather than trusted.
+Two unfinished reservations matching the same inputs is an error, not a guess.
+
+An existing tag is only accepted as "already done" when it resolves to the reserved commit.
+Treating mere existence as done would bless a release whose tag targets a different tree
+than the packages that were published.
 
 ### Reservation and concurrency
 
@@ -418,3 +467,68 @@ reuses a stale SDK that merely shares a feature band. Manifest paths remain band
 
 Shell tests run under stock macOS Bash 3.2 (no `${var,,}`), and cover spaced paths, empty and
 transport-failed version queries, and mixed-band `UpdateAllWorkloads`.
+
+
+## Deriving the next version from the feed
+
+`next-workload-version.py` picks the next global build counter from what is published, so
+every question it asks the feed has to fail closed:
+
+* **The search index is paginated.** The endpoint caps results per request, so a single
+  query saw only the first page. If the band holding the highest counter fell on a later
+  page it was invisible and the derived "next" version collided with one already published.
+  Pagination now continues until the number of entries seen matches `totalHits`, and a
+  response that delivers fewer than it promised, omits `totalHits`, or returns a
+  non-integer `totalHits` or non-list `data` aborts the run.
+* **A 200 that cannot be parsed is not an empty package.** `release-state.py` read
+  `payload.get("versions", [])`, so `{}` — a truncated or error-shaped body — made a
+  published package look missing. That downgrades `published` to `partial`, or makes a
+  partial release look unpublished and advances past it. Only a genuine 404 (or a missing
+  file on the `file://` feed used by the tests) means "never published".
+
+`--set-version` equal to the value already on disk is an **idempotent no-op, not a failure**.
+It is called outside a condition under `set -e`, so returning non-zero killed the step and
+made the documented "reserve the current commit" recovery below it unreachable. Writing a
+*lower* version is still refused.
+
+## Installer band selection, continued
+
+**The manifest package always follows the target band.** The manifest is named after the
+band it is *for*, but the id was derived from the running SDK and only corrected on the
+auto-derived path. `-t 10.0.200` on a 10.0.100 SDK therefore downloaded
+`samsung.net.sdk.tizen.manifest-10.0.100` and installed it into `sdk-manifests/10.0.200` —
+the wrong band's manifest in the right band's directory, reported as success.
+
+**Pre-release bands are ordered by SemVer precedence.** The sort key appended the
+pre-release verbatim and the comparison is a string compare, so `preview.10` sorted *below*
+`preview.9` (`'1' < '9'`) and a request against a `preview.10` band silently fell back to
+`preview.9`. Numeric identifiers are now zero-padded and tagged, alphanumeric ones tagged
+separately (numeric sorts below alphanumeric, as SemVer requires). The shell and PowerShell
+keys are asserted byte-identical.
+
+**Installing is one transaction.** A partial install is worse than none: the shell installer
+left `global.json` pinned when a download failed — so the next iteration of an
+`--update-all-workloads` run overwrote the user's real `global.json.bak` and destroyed it —
+and a failed pack install left a new manifest advertising packs that were not on disk, so
+every later build against that band failed with an unrelated-looking error. The PowerShell
+installer was worse still: it *removed* the old manifest and packs before fetching the new
+ones, so a mid-way failure left no workload at all. Both now roll the SDK back to exactly
+its previous state on any failure, including restoring `global.json` verbatim.
+
+## Testing the shipped code
+
+The fallback tests used to re-implement the family-prefix rule with their own `sed`, so they
+agreed with themselves no matter what the installer did and could never detect drift. The
+resolver is now delimited by `# BEGIN/END FALLBACK RESOLVER` markers, extracted, and invoked
+directly — as `compute_target_version_band` and `band_sort_key` already were. Regressing
+`band_sort_key` to its previous form makes the suite fail, which is the property that
+matters.
+
+The package set lives in three places — the workflow's push loop, `release-state.py`, and
+the reservation payload — and is now checked in **both** directions. The old check only
+verified that everything pushed was tracked; a package tracked but never pushed could never
+become present, so the completeness gate would retry until it gave up and the version could
+never be tagged.
+
+SDK bootstrap directories and install stamps are keyed by the **full** SDK version, so
+`10.0.100` and `10.0.101` do not share a tree, while the manifest path stays band-based.

--- a/workload/docs/net11.md
+++ b/workload/docs/net11.md
@@ -75,7 +75,7 @@ eventual `11.0.100` GA need no further code change. This is asserted by
 | `test-version-band` | SDK version → feature band across **both installers and Config.mk**, fallback band family, band isolation |
 | `test-template-conditions` | template platform detection across TFMs |
 | `test-package-fallback` | fallback filtering, plus selection priority / atomicity in both directory-creation orders |
-| `test-release-workflow` | release ordering, retryability, non-mutating reference-only runs |
+| `test-release-workflow` | release ordering, retryability, partial-publication resume, failure injection |
 | `test-install-failure` | installer exit codes, fallback package **id**, SDK-pin verification, empty/transport responses |
 | `Generate-InstallScripts.ps1 -Check` | version-map drift **and** install-script integrity |
 
@@ -121,6 +121,12 @@ Two properties are load-bearing:
   next SDK's install. Both are fixed and pinned by `scripts/test-install-failure.sh`.
 
 An 11.x request with no 11.x map entry fails closed.
+
+A manifest version is required unconditionally, whichever branch produced it. An explicit
+`-Version ""` (or whitespace) does not equal `"<latest>"`, so it used to bypass resolution and
+validation entirely, remove the installed manifest, and construct a **versionless** NuGet URL —
+and the v2 package endpoint serves the **latest** package for such a URL. The gate now runs
+before any removal, URL construction or download.
 
 The resolved version is validated before use. An empty or all-blank `versions[]` from the feed
 is rejected rather than returned as a truthy `"<id>="`: the NuGet v2 package endpoint serves the
@@ -319,4 +325,36 @@ on NuGet, so when the branch already carries the intended still-unpublished vers
 A reference-only run (`release_manifest=false`) publishes no manifest and is completely
 non-mutating: no bump, no commit, no tag.
 
-`scripts/test-release-workflow.sh` pins all of the above.
+### Resuming a partially published release
+
+Publication is not atomic: the companion packs, the manifest, the tag and the GitHub release
+are separate steps. If one fails partway, version V is *partially* published — and because
+`next-workload-version.py` derives the next version from what exists on NuGet, it then answers
+V+1. Advancing at that point strands V permanently with no tag, no release and a missing pack
+set.
+
+`scripts/release-state.py` makes that state explicit (`unpublished` / `partial` / `published`),
+and the workflow resumes V unless it is provably complete:
+
+| State of the branch's version | Action |
+|---|---|
+| `partial` | **always resume V** — never advance |
+| `published` but no tag/release | resume V to finish the tag/release |
+| `unpublished` and branch already carries it | resume V |
+| `published` **and** released | safe to compute V+1 |
+
+Two supporting properties:
+
+* **The manifest is published last.** It is what `next-workload-version.py` keys off, so
+  publishing it only after its companion packs means an interruption cannot leave a version
+  that looks advanceable while its packs are missing.
+* **Every push is idempotent** (`--skip-duplicate`). NuGet packages are immutable, so an
+  id+version that already exists *is* the intended artifact and is skipped; only missing
+  artifacts are published. Completeness is re-verified (with retries for feed lag) before the
+  tag is created, and re-creating an existing tag is a no-op.
+
+A feed transport failure exits non-zero rather than being read as `unpublished` — otherwise a
+network blip would advance the version and strand the release it was meant to protect.
+
+`scripts/test-release-workflow.sh` pins all of the above, including failure injection at each
+publication step.

--- a/workload/scripts/Generate-InstallScripts.ps1
+++ b/workload/scripts/Generate-InstallScripts.ps1
@@ -137,6 +137,30 @@ Please add these markers around the existing LatestVersionMap block, then rerun.
     return $replaced
 }
 
+function Test-ScriptIntegrity {
+    <#
+        Guards against the file-truncation / NUL-padding corruption that silently landed
+        in workload-install.sh (see git history around the version-map SSOT change).
+        The version-map drift check alone cannot catch it: it only compares the
+        auto-generated block, so a script whose *tail* is missing still reports "OK".
+    #>
+    param([string]$Path, [string]$ExpectedTail)
+
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    if ($bytes -contains 0) {
+        Write-Host "  CORRUPT: $Path contains NUL bytes." -ForegroundColor Red
+        return $false
+    }
+    $text = [System.Text.Encoding]::UTF8.GetString($bytes)
+    if ($text.TrimEnd() -notmatch ([regex]::Escape($ExpectedTail) + '\s*$')) {
+        Write-Host "  TRUNCATED: $Path does not end with '$ExpectedTail'." -ForegroundColor Red
+        Write-Host ("    actual tail: " + ($text.TrimEnd() -split "`r?`n" | Select-Object -Last 1))
+        return $false
+    }
+    Write-Host "  OK: $Path integrity (no NULs, expected tail)." -ForegroundColor Green
+    return $true
+}
+
 function Detect-LineEnding {
     param([string]$Path)
     $bytes = [System.IO.File]::ReadAllBytes($Path)
@@ -196,6 +220,16 @@ $ps1New    = Replace-Block -FilePath $Ps1Path -NewBlock $ps1Block -LineEnding $p
 
 $okSh  = Write-Or-Check -Path $ShPath  -NewContent $shNew  -CheckOnly:$Check
 $okPs1 = Write-Or-Check -Path $Ps1Path -NewContent $ps1New -CheckOnly:$Check
+
+$intactSh  = Test-ScriptIntegrity -Path $ShPath  -ExpectedTail 'echo "DONE"'
+$intactPs1 = Test-ScriptIntegrity -Path $Ps1Path -ExpectedTail 'Write-Host "`nDone"'
+
+if (-not $intactSh -or -not $intactPs1) {
+    Write-Host ""
+    Write-Host "An install script is corrupt (truncated or NUL-padded)." -ForegroundColor Red
+    Write-Host "Restore it from git history before regenerating the version map."
+    exit 1
+}
 
 if ($Check -and (-not $okSh -or -not $okPs1)) {
     Write-Host ""

--- a/workload/scripts/README.md
+++ b/workload/scripts/README.md
@@ -62,13 +62,22 @@ download a 404. Add the entry *after* the release, not before — see commit
 ## test-version-band
 
 `Generate-InstallScripts.ps1 -Check` only compares the generated version-map block, so it cannot
-see problems elsewhere in the installers. Two extra guards cover that gap:
+see problems elsewhere in the installers. Several extra guards cover that gap:
 
 * [`test-version-band.sh`](./test-version-band.sh) asserts the SDK-version → feature-band mapping
-  (for example `11.0.100-preview.7.26381.103` → `11.0.100-preview.7`) and checks that
-  `workload-install.sh` and `workload-install.ps1` agree. The bash implementation is extracted
-  live from `workload-install.sh` between the `BEGIN/END VERSION BAND DETECTION` markers, so the
-  test always exercises shipped code — keep those markers intact.
+  (for example `11.0.100-preview.7.26381.103` → `11.0.100-preview.7`). It extracts the bash
+  implementation from `workload-install.sh` and the PowerShell one from `workload-install.ps1`,
+  in both cases between the `BEGIN/END VERSION BAND DETECTION` markers, and additionally compares
+  both against `Config.mk`'s `DOTNET_VERSION_BAND`. Extracting the real code — rather than
+  reimplementing it in the test — is what lets the test detect the two installers drifting apart.
+  It also pins the manifest fallback band family and `DOTNET_DESTDIR` band isolation.
+  **Keep those markers intact.**
+* [`test-template-conditions.sh`](./test-template-conditions.sh) extracts the template's platform
+  detection `PropertyGroup` (between the `BEGIN/END TIZEN UI PLATFORM DETECTION` markers) and
+  pins it across 13 TFMs.
+* [`test-install-failure.sh`](./test-install-failure.sh) pins installer exit codes: a failed
+  install must exit non-zero rather than printing `DONE` and exiting 0.
+* `test-matrix.sh --self-test` pins matrix row selection without needing a dotnet install.
 * `Generate-InstallScripts.ps1` additionally verifies both installers contain no NUL bytes and
   end with their expected final statement. Both scripts had previously been committed truncated
   mid-statement and NUL-padded, which the version-map drift check reported as "OK".
@@ -78,6 +87,9 @@ Run everything at once with:
 ```
 make -C workload check
 ```
+
+`pwsh` is required for the drift/integrity checks. Without it `make check` fails with an
+actionable message; use `make check SKIP_PWSH_CHECKS=1` to proceed with those unverified.
 
 ### Why
 

--- a/workload/scripts/README.md
+++ b/workload/scripts/README.md
@@ -51,6 +51,34 @@ To add or update an entry:
 The CI workflow `validate-version-map.yml` runs `Generate-InstallScripts.ps1 -Check`
 on every PR and fails if the two scripts have drifted from `version-map.json`.
 
+### When *not* to add an entry
+
+`LatestVersionMap` is a **fallback cache of already-published manifest versions**. It is only
+consulted when the live NuGet lookup fails. Adding an entry for an SDK band whose
+`Samsung.NET.Sdk.Tizen.Manifest-<band>` package has never been released makes the installer
+download a 404. Add the entry *after* the release, not before — see commit
+`chore: add 10.0.300 -> 10.0.127 to version map`.
+
+## test-version-band
+
+`Generate-InstallScripts.ps1 -Check` only compares the generated version-map block, so it cannot
+see problems elsewhere in the installers. Two extra guards cover that gap:
+
+* [`test-version-band.sh`](./test-version-band.sh) asserts the SDK-version → feature-band mapping
+  (for example `11.0.100-preview.7.26381.103` → `11.0.100-preview.7`) and checks that
+  `workload-install.sh` and `workload-install.ps1` agree. The bash implementation is extracted
+  live from `workload-install.sh` between the `BEGIN/END VERSION BAND DETECTION` markers, so the
+  test always exercises shipped code — keep those markers intact.
+* `Generate-InstallScripts.ps1` additionally verifies both installers contain no NUL bytes and
+  end with their expected final statement. Both scripts had previously been committed truncated
+  mid-statement and NUL-padded, which the version-map drift check reported as "OK".
+
+Run everything at once with:
+
+```
+make -C workload check
+```
+
 ### Why
 
 Previously, the same ~36 entries were maintained by hand in two different languages

--- a/workload/scripts/next-workload-version.py
+++ b/workload/scripts/next-workload-version.py
@@ -9,7 +9,7 @@ package published on NuGet, finding the largest globally-sequential build counte
 and returning it incremented by 1.
 
 Rationale
-=========
+---------
 TizenWorkloadVersion uses the format `<TizenOSMajor>.<TizenOSMinor>.<buildSeq>` where
 `buildSeq` increments by 1 per release REGARDLESS of which .NET SDK band the release
 targets. Every active branch (main, net7.0, net8.0, net9.0, net10.0) draws from the
@@ -17,7 +17,7 @@ same `buildSeq` pool. NuGet is the source of truth: the next number must be 1 mo
 than the largest `buildSeq` ever published, irrespective of sdkBand or branch.
 
 Algorithm
-=========
+---------
 1. Query NuGet's search index for all packages whose id starts with
    `samsung.net.sdk.tizen.manifest-`. This returns one entry per sdkBand (one
    package per band, e.g. ...-7.0.400, ...-8.0.100-rtm, etc.).
@@ -28,7 +28,7 @@ Algorithm
 5. Print `<major>.<minor>.<buildSeq+1>` on stdout (single line, no extras).
 
 Usage
-=====
+-----
     # Print only:
     python3 workload/scripts/next-workload-version.py
 
@@ -39,7 +39,7 @@ Usage
     python3 workload/scripts/next-workload-version.py --verbose
 
 Notes
-=====
+-----
 - Reads no local files; relies only on what is published to nuget.org. This is
   intentional: published artifacts are the authoritative shared sequence; uncommitted
   Versions.props bumps cannot influence the answer.
@@ -50,6 +50,7 @@ Notes
 from __future__ import annotations
 import argparse
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -57,17 +58,24 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+# Overridable so the tests can point the queries at a local stub feed. Defaults are the
+# production endpoints; nothing in CI or a real release sets these.
+SEARCH_BASE = os.environ.get("TIZEN_NUGET_SEARCH_BASE", "https://azuresearch-usnc.nuget.org/query")
+FLATCONTAINER_BASE = os.environ.get(
+    "TIZEN_NUGET_FEED_BASE", "https://api.nuget.org/v3-flatcontainer"
+)
+
 SEARCH_URL = (
-    "https://azuresearch-usnc.nuget.org/query"
-    "?q=packageid:samsung.net.sdk.tizen.manifest"
-    "&prerelease=true&semVerLevel=2.0.0&take=200"
+    SEARCH_BASE + "?q=packageid:samsung.net.sdk.tizen.manifest"
+    "&prerelease=true&semVerLevel=2.0.0"
 )
 SEARCH_FALLBACK_URL = (
-    "https://azuresearch-usnc.nuget.org/query"
-    "?q=samsung.net.sdk.tizen.manifest"
-    "&prerelease=true&semVerLevel=2.0.0&take=200"
+    SEARCH_BASE + "?q=samsung.net.sdk.tizen.manifest"
+    "&prerelease=true&semVerLevel=2.0.0"
 )
-FLATCONTAINER_FMT = "https://api.nuget.org/v3-flatcontainer/{id}/index.json"
+PAGE_SIZE = 200
+
+FLATCONTAINER_FMT = FLATCONTAINER_BASE.rstrip("/") + "/{id}/index.json"
 
 VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
 
@@ -80,25 +88,102 @@ def fetch_json(url: str, timeout: int = 15) -> dict:
         raise SystemExit(f"network error fetching {url}: {e}")
 
 
-def find_manifest_package_ids(verbose: bool = False) -> list[str]:
-    """Return lowercase ids of every published samsung.net.sdk.tizen.manifest-* package."""
+def search_page(url_base: str, skip: int, take: int) -> tuple[int, list]:
+    """One page of a NuGet search query, with the response strictly validated.
+
+    Returns (totalHits, entries). Every structural surprise raises: a search response we
+    cannot fully understand must never be reduced to "fewer packages exist".
+    """
+    url = "{0}&skip={1}&take={2}".format(url_base, skip, take)
+    data = fetch_json(url)
+    if not isinstance(data, dict):
+        raise SystemExit(f"unexpected search response for {url}: not a JSON object")
+    if "totalHits" not in data:
+        raise SystemExit(f"search response for {url} has no 'totalHits'; refusing to guess")
+    total = data["totalHits"]
+    if not isinstance(total, int) or isinstance(total, bool) or total < 0:
+        raise SystemExit(f"search response for {url} has a bad 'totalHits': {total!r}")
+    entries = data.get("data")
+    if not isinstance(entries, list):
+        raise SystemExit(
+            f"search response for {url} has a non-list 'data': {type(entries).__name__}"
+        )
+    return total, entries
+
+
+def collect_ids(url_base: str, verbose: bool = False) -> set[str]:
+    """Every matching package id from url_base, paginating until totalHits is satisfied.
+
+    The search endpoint caps `take`, so a single request silently returned only the first
+    page. Reading one page and treating it as the whole world meant a band whose entry fell
+    on page 2 was invisible - and if that band held the highest build counter, the derived
+    "next" version collided with one already published. Pagination continues until the
+    number of entries seen matches totalHits; anything less is a hard error.
+    """
     out: set[str] = set()
-    for url in (SEARCH_URL, SEARCH_FALLBACK_URL):
-        try:
-            data = fetch_json(url)
-        except SystemExit:
-            continue
-        for entry in data.get("data", []):
-            pid = entry.get("id", "").lower()
+    skip = 0
+    seen = 0
+    total: int | None = None
+    while True:
+        page_total, entries = search_page(url_base, skip, PAGE_SIZE)
+        if total is None:
+            total = page_total
+        elif page_total != total:
+            raise SystemExit(
+                f"totalHits changed mid-pagination ({total} -> {page_total}); the feed is "
+                f"not stable enough to derive a version from."
+            )
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise SystemExit(f"unexpected search entry: {type(entry).__name__}")
+            pid = entry.get("id", "")
+            if not isinstance(pid, str):
+                raise SystemExit(f"unexpected package id: {pid!r}")
+            pid = pid.lower()
             # Accept both exact 'samsung.net.sdk.tizen.manifest' (no suffix, unusual)
             # and the typical '-<band>' suffix forms.
             if pid.startswith("samsung.net.sdk.tizen.manifest"):
                 out.add(pid)
-        if out:
+        seen += len(entries)
+        if seen >= total:
             break
+        if not entries:
+            # More were promised than delivered: stop rather than spin, and fail closed.
+            raise SystemExit(
+                f"search returned {seen} of {total} promised entries for {url_base}; "
+                f"refusing to derive a version from an incomplete package list."
+            )
+        skip += len(entries)
     if verbose:
-        print(f"[verbose] discovered {len(out)} manifest package ids", file=sys.stderr)
-    return sorted(out)
+        print(
+            f"[verbose] {url_base}: {seen}/{total} entries, {len(out)} manifest ids",
+            file=sys.stderr,
+        )
+    return out
+
+
+def find_manifest_package_ids(verbose: bool = False) -> list[str]:
+    """Return lowercase ids of every published samsung.net.sdk.tizen.manifest-* package."""
+    problems: list[str] = []
+    for url in (SEARCH_URL, SEARCH_FALLBACK_URL):
+        try:
+            out = collect_ids(url, verbose=verbose)
+        except SystemExit as exc:
+            # Remember it: if every query form fails we must abort rather than proceed
+            # with no data, which would look exactly like "nothing is published yet".
+            problems.append(f"{url}: {exc}")
+            continue
+        if out:
+            if verbose:
+                print(f"[verbose] discovered {len(out)} manifest package ids", file=sys.stderr)
+            return sorted(out)
+    if problems:
+        raise SystemExit(
+            "could not enumerate the manifest packages: "
+            + "; ".join(problems)
+            + ". Refusing to derive a version from incomplete feed data."
+        )
+    return []
 
 
 def fetch_versions(pid: str, verbose: bool = False) -> list[str]:
@@ -157,7 +242,9 @@ def find_max_triple(verbose: bool = False) -> tuple[int, int, int]:
     return best
 
 
-def update_versions_props(versions_props: Path, new_value: str, verbose: bool = False) -> int:
+def update_versions_props(
+    versions_props: Path, new_value: str, verbose: bool = False, allow_noop: bool = False
+) -> int:
     text = versions_props.read_text(encoding="utf-8")
     m = re.search(r"<TizenWorkloadVersion>([^<]+)</TizenWorkloadVersion>", text)
     if not m:
@@ -172,6 +259,13 @@ def update_versions_props(versions_props: Path, new_value: str, verbose: bool = 
         raise SystemExit(f"unparseable current version: {current!r}")
     if new_t is None:
         raise SystemExit(f"unparseable new version: {new_value!r}")
+
+    if allow_noop and new_t == cur_t:
+        print(
+            f"TizenWorkloadVersion is already {new_value}; nothing to write.",
+            file=sys.stderr,
+        )
+        return 0
 
     if new_t <= cur_t:
         print(
@@ -222,7 +316,12 @@ def main() -> int:
         else:
             # script is in workload/scripts/, so Versions.props is sibling-of-parent/build/
             vp = Path(__file__).resolve().parents[1] / "build" / "Versions.props"
-        rc = update_versions_props(vp, next_value, verbose=args.verbose)
+        # An explicit --set-version that equals what is already on disk is the resume
+        # case: a previous run bumped the file but never got as far as reserving it.
+        # That is a no-op, not a failure - the caller reserves the current commit.
+        rc = update_versions_props(
+            vp, next_value, verbose=args.verbose, allow_noop=bool(args.set_version)
+        )
         # Always echo the computed value so CI/scripts can capture it.
         print(next_value)
         return rc

--- a/workload/scripts/next-workload-version.py
+++ b/workload/scripts/next-workload-version.py
@@ -102,14 +102,31 @@ def find_manifest_package_ids(verbose: bool = False) -> list[str]:
 
 
 def fetch_versions(pid: str, verbose: bool = False) -> list[str]:
+    """Versions of an authoritative package.
+
+    Any transport, status or parse failure ABORTS. Returning an empty list on failure
+    silently lowered the global maximum: if the query that failed happened to be the
+    package holding the highest build counter, the next version would collide with one
+    that is already published. Being unable to see the whole picture is never the same
+    as seeing an empty one.
+    """
     url = FLATCONTAINER_FMT.format(id=pid)
     try:
         data = fetch_json(url)
-    except SystemExit:
-        if verbose:
-            print(f"[verbose] failed to fetch versions for {pid}", file=sys.stderr)
-        return []
-    return data.get("versions", [])
+    except SystemExit as exc:
+        raise SystemExit(
+            f"failed to fetch versions for {pid}: {exc}. Refusing to derive a version "
+            f"from incomplete feed data."
+        )
+    if not isinstance(data, dict) or "versions" not in data:
+        raise SystemExit(
+            f"unexpected response for {pid} (no 'versions' array). Refusing to derive a "
+            f"version from unparseable feed data."
+        )
+    versions = data.get("versions")
+    if not isinstance(versions, list):
+        raise SystemExit(f"unexpected 'versions' payload for {pid}: {type(versions).__name__}")
+    return versions
 
 
 def parse_version(v: str) -> tuple[int, int, int] | None:
@@ -183,10 +200,21 @@ def main() -> int:
     p.add_argument("--versions-props", default=None,
                    help="Path to Versions.props (default: workload/build/Versions.props relative to this script).")
     p.add_argument("--verbose", action="store_true", help="Print diagnostics on stderr.")
+    p.add_argument("--set-version", default=None,
+                   help="Write this exact version instead of re-deriving it. Use with --apply "
+                        "so a caller that already computed a candidate cannot have a "
+                        "concurrent release change the value between compute and apply.")
     args = p.parse_args()
 
-    major, minor, build = find_max_triple(verbose=args.verbose)
-    next_value = f"{major}.{minor}.{build + 1}"
+    if args.set_version:
+        if not args.apply:
+            raise SystemExit("--set-version requires --apply")
+        next_value = args.set_version.strip()
+        if not VERSION_RE.match(next_value):
+            raise SystemExit(f"--set-version {next_value!r} is not a valid workload version")
+    else:
+        major, minor, build = find_max_triple(verbose=args.verbose)
+        next_value = f"{major}.{minor}.{build + 1}"
 
     if args.apply:
         if args.versions_props:

--- a/workload/scripts/release-reservation.py
+++ b/workload/scripts/release-reservation.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+"""
+Encode and verify the payload of a release reservation.
+
+Why a payload at all
+--------------------
+A reservation used to be nothing but a ref pointing at a commit. That is enough to answer
+"is this version taken", but not "is this run allowed to continue it". Two failures follow
+from a bare ref:
+
+  * A re-run of a dispatch checks out the SHA of the ORIGINAL event, so `Versions.props` on
+    disk still holds the pre-bump version. Deciding what to resume from that value makes a
+    re-run look at a version it already finished, conclude there is nothing to resume, and
+    then abort against its own reservation.
+  * Nothing tied the reservation to the inputs it was made for. Re-dispatching with a
+    different `net_sdk_version` would happily resume a reservation created for another SDK
+    band and publish a manifest built for the wrong one.
+
+So the reservation records the complete set of release inputs, and a run that wants to
+continue it must match them exactly.
+
+Format
+------
+The reservation ref (`refs/tizen-release/v<version>`) points at an annotated tag object
+whose message contains one line of JSON:
+
+  {"version", "sha", "sdk", "band", "manifest_id", "packages", "branch"}
+
+`sha` is the reserved release commit: the single commit every artifact for this version
+must be built from, on the first attempt and on every retry.
+
+Commands
+--------
+  encode   build the payload from explicit inputs (prints one line of JSON)
+  verify   check a payload against the inputs of the run that wants to use it
+
+Exit codes
+----------
+  0  ok
+  2  usage/parse error
+  3  the reservation does not match the run's inputs (do NOT resume it)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+FIELDS = ("version", "sha", "sdk", "band", "manifest_id", "packages", "branch")
+
+
+def encode(args: argparse.Namespace) -> int:
+    packages = [p.strip() for p in args.packages.split(",") if p.strip()]
+    if not packages:
+        print("ERROR: --packages must list at least one package id", file=sys.stderr)
+        return 2
+    if len(args.sha) != 40 or not all(c in "0123456789abcdef" for c in args.sha.lower()):
+        print(f"ERROR: --sha must be a full 40-character commit id, got {args.sha!r}",
+              file=sys.stderr)
+        return 2
+    payload = {
+        "version": args.version.strip(),
+        "sha": args.sha.strip().lower(),
+        "sdk": args.sdk.strip(),
+        "band": args.band.strip(),
+        "manifest_id": args.manifest_id.strip(),
+        "packages": sorted(packages),
+        "branch": args.branch.strip(),
+    }
+    for key in FIELDS:
+        if not payload[key]:
+            print(f"ERROR: {key} must not be empty", file=sys.stderr)
+            return 2
+    # separators= keeps it on a single line so `git cat-file -p` output can be grepped.
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def load_payload(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        text = handle.read()
+    # Tolerate the surrounding tag-object headers: take the first line that looks like the
+    # payload object.
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            return json.loads(line)
+    raise ValueError("no JSON payload found")
+
+
+def verify(args: argparse.Namespace) -> int:
+    try:
+        payload = load_payload(args.payload_file)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: unreadable reservation payload: {exc}", file=sys.stderr)
+        return 2
+
+    if not isinstance(payload, dict):
+        print("ERROR: reservation payload is not an object", file=sys.stderr)
+        return 2
+    missing = [f for f in FIELDS if f not in payload]
+    if missing:
+        # An older, bare reservation cannot be validated, so it cannot be resumed.
+        print(
+            "ERROR: reservation is missing required field(s): "
+            + ", ".join(missing)
+            + ". Refusing to resume a reservation whose release inputs are unknown.",
+            file=sys.stderr,
+        )
+        return 3
+
+    problems = []
+    checks = [
+        ("version", args.expect_version),
+        ("sdk", args.expect_sdk),
+        ("band", args.expect_band),
+        ("branch", args.expect_branch),
+        ("manifest_id", args.expect_manifest_id),
+        ("sha", args.expect_sha),
+    ]
+    for key, expected in checks:
+        if expected is None:
+            continue
+        actual = payload.get(key)
+        if isinstance(actual, str) and isinstance(expected, str):
+            same = actual.strip() == expected.strip()
+        else:
+            same = actual == expected
+        if not same:
+            problems.append(f"{key}: reserved {actual!r} but this run has {expected!r}")
+
+    if args.expect_packages is not None:
+        expected_pkgs = sorted(p.strip() for p in args.expect_packages.split(",") if p.strip())
+        actual_pkgs = payload.get("packages")
+        if not isinstance(actual_pkgs, list):
+            problems.append("packages: reservation payload has a non-list 'packages'")
+        elif sorted(actual_pkgs) != expected_pkgs:
+            problems.append(
+                f"packages: reserved {sorted(actual_pkgs)} but this run expects {expected_pkgs}"
+            )
+
+    if problems:
+        print(
+            "ERROR: reservation v{0} does not match this run:".format(payload.get("version")),
+            file=sys.stderr,
+        )
+        for problem in problems:
+            print("  - " + problem, file=sys.stderr)
+        print(
+            "Refusing to resume it. A reservation may only be continued by a run with the "
+            "same release inputs.",
+            file=sys.stderr,
+        )
+        return 3
+
+    if args.print_field:
+        value = payload.get(args.print_field)
+        print(",".join(value) if isinstance(value, list) else value)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    enc = sub.add_parser("encode", help="build a reservation payload")
+    for flag in ("version", "sha", "sdk", "band", "manifest-id", "packages", "branch"):
+        enc.add_argument("--" + flag, required=True)
+    enc.set_defaults(func=encode)
+
+    ver = sub.add_parser("verify", help="check a reservation against this run's inputs")
+    ver.add_argument("--payload-file", required=True)
+    for flag in ("version", "sha", "sdk", "band", "branch", "manifest-id", "packages"):
+        ver.add_argument("--expect-" + flag, default=None)
+    ver.add_argument("--print-field", default=None,
+                     help="on success, print this field from the payload")
+    ver.set_defaults(func=verify)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workload/scripts/release-state.py
+++ b/workload/scripts/release-state.py
@@ -21,14 +21,14 @@ This script makes that state explicit so the workflow can resume V instead of ad
 NuGet packages are immutable, so "already present" is always safe to skip.
 
 States
-======
+------
   unpublished  none of the expected packages exist for V
   partial      some (but not all) expected packages exist for V
   published    every expected package exists for V
                (the caller still has to check the tag/release before treating V as done)
 
 Outputs
-=======
+-------
 Emits `key=value` lines suitable for appending to $GITHUB_OUTPUT:
 
   state=unpublished|partial|published
@@ -36,12 +36,12 @@ Emits `key=value` lines suitable for appending to $GITHUB_OUTPUT:
   missing=<comma-separated package ids that do not>
 
 Exit codes
-==========
+----------
   0  state determined
   2  the feed could not be reached (caller must NOT advance the version on this)
 
 Testing
-=======
+-------
 `--feed-base` (or TIZEN_NUGET_FEED_BASE) overrides the flatcontainer base URL, so tests can
 point at a local directory of `<id>/index.json` files via a file:// URL.
 """
@@ -83,7 +83,31 @@ def feed_versions(feed_base: str, package_id: str) -> list:
         if url.startswith("file:") and isinstance(exc.reason, FileNotFoundError):
             return []
         raise
-    return [v for v in payload.get("versions", []) if v]
+
+    # Only a 404 means "never published". A 200 carrying something we cannot parse is a
+    # malformed response, and must NOT be read as absence: `{}` previously yielded [] via
+    # .get("versions", []), so a truncated or error-shaped body made a published package
+    # look missing - which downgrades `published` to `partial` and re-publishes, or worse
+    # makes a partial release look unpublished and advances past it.
+    if not isinstance(payload, dict):
+        raise ValueError(
+            "malformed index for {0}: expected a JSON object, got {1}".format(
+                package_id, type(payload).__name__
+            )
+        )
+    if "versions" not in payload:
+        raise ValueError(
+            "malformed index for {0}: no 'versions' key. A 200 response that cannot be "
+            "parsed is not the same as a package that was never published.".format(package_id)
+        )
+    versions = payload["versions"]
+    if not isinstance(versions, list):
+        raise ValueError(
+            "malformed index for {0}: 'versions' is {1}, expected a list".format(
+                package_id, type(versions).__name__
+            )
+        )
+    return [v for v in versions if v]
 
 
 def main() -> int:

--- a/workload/scripts/release-state.py
+++ b/workload/scripts/release-state.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+"""
+Report the publication state of a workload version so a release can be resumed.
+
+Why
+===
+The release publishes several packages and then creates a tag + GitHub release. Those
+steps are not atomic. If one fails after the manifest has been pushed, the version V is
+*partially* published:
+
+  * `next-workload-version.py` derives the next version from what exists on NuGet, so it
+    now answers V+1;
+  * the previous logic saw OLD(V) != NEW(V+1), bumped, and moved on;
+  * V therefore never receives its remaining packs, its tag, or its release - permanently.
+
+This script makes that state explicit so the workflow can resume V instead of advancing.
+NuGet packages are immutable, so "already present" is always safe to skip.
+
+States
+======
+  unpublished  none of the expected packages exist for V
+  partial      some (but not all) expected packages exist for V
+  published    every expected package exists for V
+               (the caller still has to check the tag/release before treating V as done)
+
+Outputs
+=======
+Emits `key=value` lines suitable for appending to $GITHUB_OUTPUT:
+
+  state=unpublished|partial|published
+  present=<comma-separated package ids that already exist at V>
+  missing=<comma-separated package ids that do not>
+
+Exit codes
+==========
+  0  state determined
+  2  the feed could not be reached (caller must NOT advance the version on this)
+
+Testing
+=======
+`--feed-base` (or TIZEN_NUGET_FEED_BASE) overrides the flatcontainer base URL, so tests can
+point at a local directory of `<id>/index.json` files via a file:// URL.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_FEED_BASE = "https://api.nuget.org/v3-flatcontainer"
+
+# Packages that carry the workload version. Ref packs are versioned by their TizenFX
+# version instead and are governed by the separate release_reference input.
+VERSIONED_PACKAGE_SUFFIXES = [
+    "Samsung.Tizen.Sdk",
+    "Samsung.NETCore.App.Runtime.tizen",
+    "Samsung.Tizen.Templates",
+]
+
+
+def feed_versions(feed_base: str, package_id: str) -> list:
+    """Return the published versions of package_id, or [] when it has never been published."""
+    url = "{0}/{1}/index.json".format(feed_base.rstrip("/"), package_id.lower())
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            # Genuinely never published.
+            return []
+        raise
+    except urllib.error.URLError as exc:
+        # A missing file on a file:// feed (used by the tests) is the local equivalent of a
+        # 404. Every OTHER URLError is a transport failure and must stay fatal - treating it
+        # as "unpublished" would advance the version and strand a partial release.
+        if url.startswith("file:") and isinstance(exc.reason, FileNotFoundError):
+            return []
+        raise
+    return [v for v in payload.get("versions", []) if v]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="workload version to inspect")
+    parser.add_argument("--band", required=True, help="SDK feature band, e.g. 11.0.100-preview.7")
+    parser.add_argument(
+        "--feed-base",
+        default=os.environ.get("TIZEN_NUGET_FEED_BASE", DEFAULT_FEED_BASE),
+        help="flatcontainer base URL (tests may point this at a local directory)",
+    )
+    args = parser.parse_args()
+
+    version = args.version.strip()
+    if not version:
+        print("ERROR: --version must not be empty", file=sys.stderr)
+        return 2
+
+    expected = ["Samsung.NET.Sdk.Tizen.Manifest-" + args.band] + VERSIONED_PACKAGE_SUFFIXES
+
+    present, missing = [], []
+    for package_id in expected:
+        try:
+            versions = feed_versions(args.feed_base, package_id)
+        except Exception as exc:  # noqa: BLE001 - any transport failure is fatal here
+            print("ERROR: could not query {0}: {1}".format(package_id, exc), file=sys.stderr)
+            # Never let a transport failure look like "unpublished": that would advance the
+            # version and strand a partially published release.
+            return 2
+        (present if version in versions else missing).append(package_id)
+
+    if not present:
+        state = "unpublished"
+    elif missing:
+        state = "partial"
+    else:
+        state = "published"
+
+    print("state=" + state)
+    print("present=" + ",".join(present))
+    print("missing=" + ",".join(missing))
+
+    print(
+        "Version {0} (band {1}): {2} - {3}/{4} expected package(s) published".format(
+            version, args.band, state, len(present), len(expected)
+        ),
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workload/scripts/stub-nuget-search.py
+++ b/workload/scripts/stub-nuget-search.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+"""Serve a stub NuGet search + flatcontainer feed and run next-workload-version.py against it.
+
+Used by test-release-workflow.sh to exercise the search pagination path offline. The stub
+deliberately puts the HIGHEST build counter on the LAST page: a reader that takes only the
+first page returns a version that is already published.
+
+Usage: stub-nuget-search.py <ok|truncated|nototal|badtotal>
+Prints "rc=<exit> out=<stdout>" for the caller to assert on.
+"""
+import http.server, json, threading, subprocess, os, sys, urllib.parse
+# 3 pages of 2 entries; the HIGHEST build counter lives on page 3 (previously invisible).
+IDS = ["samsung.net.sdk.tizen.manifest-%d" % i for i in range(6)]
+VERS = {i: ["10.0.%d" % (100+i)] for i in range(6)}
+MODE = sys.argv[1]
+class H(http.server.BaseHTTPRequestHandler):
+    def log_message(self,*a): pass
+    def do_GET(self):
+        u = urllib.parse.urlparse(self.path); q = urllib.parse.parse_qs(u.query)
+        if u.path == "/query":
+            skip=int(q.get("skip",[0])[0]); take=2
+            page = IDS[skip:skip+take]
+            body = {"totalHits": len(IDS), "data": [{"id": i} for i in page]}
+            if MODE == "truncated" and skip == 0:
+                body = {"totalHits": len(IDS), "data": [{"id": i} for i in IDS[:2]]}
+                # then serve nothing further
+            if MODE == "truncated" and skip > 0:
+                body = {"totalHits": len(IDS), "data": []}
+            if MODE == "nototal": body.pop("totalHits")
+            if MODE == "badtotal": body["totalHits"] = "six"
+        else:
+            pid = u.path.strip("/").split("/")[0]
+            idx = IDS.index(pid) if pid in IDS else None
+            body = {"versions": VERS[idx]} if idx is not None else {"versions": []}
+        b = json.dumps(body).encode()
+        self.send_response(200); self.send_header("Content-Type","application/json")
+        self.send_header("Content-Length",str(len(b))); self.end_headers(); self.wfile.write(b)
+srv = http.server.HTTPServer(("127.0.0.1",0), H)
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+port = srv.server_address[1]
+env = dict(os.environ, TIZEN_NUGET_SEARCH_BASE="http://127.0.0.1:%d/query"%port,
+           TIZEN_NUGET_FEED_BASE="http://127.0.0.1:%d"%port)
+here = os.path.dirname(os.path.abspath(__file__))
+r = subprocess.run([sys.executable, os.path.join(here, "next-workload-version.py")],env=env,
+                   capture_output=True,text=True)
+print("rc=%d out=%s" % (r.returncode, r.stdout.strip()))

--- a/workload/scripts/test-install-failure.sh
+++ b/workload/scripts/test-install-failure.sh
@@ -299,6 +299,118 @@ else
     fail=$((fail + 1))
 fi
 
+# --- 9. SDK pin must be verified before installing -----------------------------
+#
+# install_tizenworkload is invoked under `if !`, which disables errexit for everything it
+# calls. An unchecked `dotnet new globaljson` therefore let the install proceed against
+# whatever SDK the PATH happened to resolve. The pin is now checked, and the EFFECTIVE
+# version/band re-verified, before any pack is installed.
+
+echo ""
+echo "-- SDK pin verified before install --"
+
+PINDIR="$TMPROOT/pinbad"
+mkdir -p "$PINDIR"
+cat > "$PINDIR/dotnet" <<'STUB'
+#!/bin/bash
+if [ "$1" = "--version" ]; then
+    # Model a pin that silently does not take effect.
+    if [ -f "$PWD/global.json" ]; then echo "9.0.100"; else echo "10.0.100"; fi
+    exit 0
+fi
+if [ "$1" = "new" ] && [ "$2" = "globaljson" ]; then
+    printf '{"sdk":{"version":"x"}}' > "$PWD/global.json"; exit 0
+fi
+case "$1" in
+    --list-sdks) echo "10.0.100 [$(dirname "$0")/sdk]" ;;
+    workload)    echo "REACHED_INSTALL"; exit 0 ;;
+    *)           exit 0 ;;
+esac
+STUB
+chmod +x "$PINDIR/dotnet"
+
+if curl -sSf -m 20 -o /dev/null https://api.nuget.org/v3/index.json 2>/dev/null; then
+    pin_out="$(cd "$TMPROOT" && bash "$SH_SCRIPT" -d "$PINDIR" 2>&1)"; pin_rc=$?
+    if [[ $pin_rc -ne 0 ]] && grep -q "pin did not take effect" <<< "$pin_out" && ! grep -q "REACHED_INSTALL" <<< "$pin_out"; then
+        printf "  %sPASS%s  ineffective SDK pin aborts before install\n" "$c_green" "$c_reset"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  ineffective SDK pin did not abort (exit %s)\n" "$c_red" "$c_reset" "$pin_rc"
+        echo "$pin_out" | tail -5 | sed 's/^/        | /'
+        fail=$((fail + 1))
+    fi
+
+    # A pin that DOES take effect must install normally.
+    PINOK="$TMPROOT/pinok"
+    mkdir -p "$PINOK"
+    cat > "$PINOK/dotnet" <<'STUB'
+#!/bin/bash
+case "$1" in
+    --version)   echo "10.0.100" ;;
+    --list-sdks) echo "10.0.100 [$(dirname "$0")/sdk]" ;;
+    new)         exit 0 ;;
+    workload)    exit 0 ;;
+    *)           exit 0 ;;
+esac
+STUB
+    chmod +x "$PINOK/dotnet"
+    ok_out="$(cd "$TMPROOT" && bash "$SH_SCRIPT" -d "$PINOK" 2>&1)"; ok_rc=$?
+    if [[ $ok_rc -eq 0 ]] && grep -q "^DONE$" <<< "$ok_out"; then
+        printf "  %sPASS%s  effective SDK pin installs normally\n" "$c_green" "$c_reset"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  effective SDK pin failed (exit %s)\n" "$c_red" "$c_reset" "$ok_rc"
+        echo "$ok_out" | tail -5 | sed 's/^/        | /'
+        fail=$((fail + 1))
+    fi
+else
+    printf "  %sSKIP%s  SDK pin verification (no network)\n" "$c_yellow" "$c_reset"
+fi
+
+# --- 10. empty feed response must not install "latest" -------------------------
+#
+# The NuGet v2 package endpoint serves the LATEST version when the URL carries no version
+# segment, so an empty resolved version must never reach the download step.
+
+echo ""
+echo "-- empty version never reaches the download URL --"
+
+if grep -q 'Refusing to install: resolved an empty manifest id/version' "$SH_SCRIPT"; then
+    printf "  %sPASS%s  workload-install.sh guards against an empty resolved version\n" "$c_green" "$c_reset"
+    pass=$((pass + 1))
+else
+    printf "  %sFAIL%s  workload-install.sh has no empty-version guard\n" "$c_red" "$c_reset"
+    fail=$((fail + 1))
+fi
+
+if command -v pwsh >/dev/null 2>&1; then
+    # An empty versions[] must NOT yield a truthy "<id>=" result.
+    cat > "$TMPROOT/empty-versions.ps1" <<'PSEOF'
+param([string]$ScriptPath)
+$src = Get-Content -Raw $ScriptPath
+if ($src -match 'Where-Object \{ \$_ -and \$_\.Trim\(\) \} \| Select-Object -Last 1') {
+    Write-Output 'GUARDED'
+} else {
+    Write-Output 'UNGUARDED'
+}
+if ($src -match 'IsNullOrWhiteSpace\(\$ResolvedVersion\)') {
+    Write-Output 'CALLER_GUARDED'
+} else {
+    Write-Output 'CALLER_UNGUARDED'
+}
+PSEOF
+    ev="$(pwsh -NoProfile -File "$TMPROOT/empty-versions.ps1" -ScriptPath "$PS1_SCRIPT" 2>/dev/null | tr -d '\r')"
+    for want in GUARDED CALLER_GUARDED; do
+        if grep -Fqx "$want" <<< "$ev"; then
+            printf "  %sPASS%s  ps1 %s\n" "$c_green" "$c_reset" "$want"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  ps1 missing %s\n" "$c_red" "$c_reset" "$want"
+            fail=$((fail + 1))
+        fi
+    done
+fi
+
 echo ""
 echo "============= install-failure summary ============="
 echo "  passed: $pass"

--- a/workload/scripts/test-install-failure.sh
+++ b/workload/scripts/test-install-failure.sh
@@ -87,6 +87,218 @@ else
     printf "  %sSKIP%s  %-52s (pwsh unavailable)\n" "$c_yellow" "$c_reset" "ps1 parity"
 fi
 
+# --- 4. fallback must resolve the package ID, not just the version -------------
+#
+# getLatestVersion previously returned only a version. The caller then downloaded that
+# version under the ORIGINAL, unpublished manifest id - e.g. a request for
+# '...manifest-10.0.400' resolved to version 10.0.127 (which belongs to
+# '...manifest-10.0.300') and then 404'd trying to fetch 10.0.400/10.0.127.
+# The function must return "<packageId>=<version>".
+
+echo ""
+echo "-- fallback resolves package id --"
+
+# Load the shipped map + function without executing the installer body.
+fallback_probe() {
+    bash -c '
+        eval "$(sed -n "/^MANIFEST_BASE_NAME=/p" '"$SH_SCRIPT"')"
+        eval "$(sed -n "/# BEGIN AUTO-GENERATED VERSION MAP/,/# END AUTO-GENERATED VERSION MAP/p" '"$SH_SCRIPT"' | grep -v "^#")"
+        eval "$(sed -n "/^function getLatestVersion/,/^}/p" '"$SH_SCRIPT"')"
+        getLatestVersion "$1"
+    ' _ "$1"
+}
+
+# "<requested band>|<expected id band>|<expected version>"  ('' = must resolve to nothing)
+FALLBACK_CASES=(
+    "10.0.400|10.0.300|10.0.127"
+    "10.0.300|10.0.300|10.0.127"
+    "9.0.400|9.0.300|10.0.121"
+    "11.0.100-preview.7||"
+    "12.0.100||"
+)
+
+for case in "${FALLBACK_CASES[@]}"; do
+    IFS='|' read -r req want_band want_ver <<< "$case"
+    base="samsung.net.sdk.tizen.manifest"
+    got="$(fallback_probe "$base-$req")"
+    if [[ -z "$want_band" ]]; then
+        if [[ -z "$got" ]]; then
+            printf "  %sPASS%s  %-24s -> resolves to nothing (fails closed)\n" "$c_green" "$c_reset" "$req"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  %-24s -> %s (expected nothing)\n" "$c_red" "$c_reset" "$req" "$got"
+            fail=$((fail + 1))
+        fi
+        continue
+    fi
+    want="$base-$want_band=$want_ver"
+    if [[ "$got" == "$want" ]]; then
+        printf "  %sPASS%s  %-24s -> %s\n" "$c_green" "$c_reset" "$req" "${got#$base-}"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-24s -> %s (expected %s)\n" "$c_red" "$c_reset" "$req" "${got:-<none>}" "$want"
+        fail=$((fail + 1))
+    fi
+done
+
+# --- 5. PowerShell parity, incl. no cross-SDK fallback leakage -----------------
+#
+# The PS installer kept the resolved fallback id in a script-level $global:FallbackId that
+# was never cleared, so an -UpdateAllWorkloads run could carry one SDK's fallback package
+# into the NEXT SDK's install. The resolved id must be per-call.
+
+if command -v pwsh >/dev/null 2>&1 && [[ -f "$PS1_SCRIPT" ]]; then
+    echo ""
+    echo "-- PowerShell fallback parity / no global leakage --"
+
+    if grep -q 'global:FallbackId' "$PS1_SCRIPT"; then
+        printf "  %sFAIL%s  workload-install.ps1 still uses \$global:FallbackId\n" "$c_red" "$c_reset"
+        fail=$((fail + 1))
+    else
+        printf "  %sPASS%s  workload-install.ps1 has no \$global:FallbackId\n" "$c_green" "$c_reset"
+        pass=$((pass + 1))
+    fi
+
+    cat > "$TMPROOT/ps-probe.ps1" <<'PSEOF'
+param([string]$ScriptPath)
+$src = Get-Content -Raw $ScriptPath
+$ManifestBaseName = 'Samsung.NET.Sdk.Tizen.Manifest'
+Invoke-Expression ([regex]::Match($src,'(?s)# BEGIN AUTO-GENERATED VERSION MAP.*?# END AUTO-GENERATED VERSION MAP').Value -replace '(?m)^#.*$','')
+Invoke-Expression ([regex]::Match($src,'(?s)# BEGIN VERSION BAND DETECTION.*?# END VERSION BAND DETECTION').Value)
+function Resolve-Offline([string]$Id) {
+    if ($LatestVersionMap.Contains($Id)) { return "$Id=$($LatestVersionMap.$Id)" }
+    $p = Get-BandFamilyPrefix -ManifestId $Id
+    if ($p) {
+        $ids = @(); $vs = @()
+        foreach ($k in $LatestVersionMap.Keys) {
+            if ($k -like "$p*") { $ids += $k; $vs += $LatestVersionMap[$k] }
+        }
+        if ($vs) { return "$($ids[-1])=$($vs[-1])" }
+    }
+    return ''
+}
+# Mixed-band sequence: a 10.x fallback must not bleed into the 11.x iteration.
+foreach ($b in @('10.0.400','11.0.100-preview.7','9.0.400')) {
+    Write-Output "$b=>$(Resolve-Offline "$ManifestBaseName-$b")"
+}
+PSEOF
+    ps_out="$(pwsh -NoProfile -File "$TMPROOT/ps-probe.ps1" -ScriptPath "$PS1_SCRIPT" 2>/dev/null | tr -d '\r')"
+
+    check_ps() {
+        local label="$1" expect="$2"
+        if grep -Fqx "$expect" <<< "$ps_out"; then
+            printf "  %sPASS%s  %-24s -> %s\n" "$c_green" "$c_reset" "$label" "${expect#*=>}"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  %-24s (got: %s)\n" "$c_red" "$c_reset" "$label" "$(grep -F "$label=>" <<< "$ps_out")"
+            fail=$((fail + 1))
+        fi
+    }
+    B=Samsung.NET.Sdk.Tizen.Manifest
+    check_ps "10.0.400" "10.0.400=>$B-10.0.300=10.0.127"
+    check_ps "11.0.100-preview.7" "11.0.100-preview.7=>"
+    check_ps "9.0.400" "9.0.400=>$B-9.0.300=10.0.121"
+else
+    echo ""
+    echo "  (pwsh unavailable - skipping PowerShell fallback parity)"
+fi
+
+# --- 6. bash 3.2 compatibility -------------------------------------------------
+#
+# macOS ships bash 3.2 and is a supported target (DOTNET_DEFAULT_PATH_MACOS). The
+# ${var,,} lowercase expansion is bash 4+ and raises "bad substitution" there, which left
+# the version empty and silently skipped the fallback path entirely.
+
+echo ""
+echo "-- bash 3.2 compatibility --"
+
+if grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*(,,|\^\^)\}' "$SH_SCRIPT" | grep -qv '^\s*[0-9]*:\s*#'; then
+    printf "  %sFAIL%s  workload-install.sh uses a bash 4+ case-conversion expansion\n" "$c_red" "$c_reset"
+    grep -nE '\$\{[A-Za-z_][A-Za-z0-9_]*(,,|\^\^)\}' "$SH_SCRIPT" | sed 's/^/        /'
+    fail=$((fail + 1))
+else
+    printf "  %sPASS%s  no bash 4+ case-conversion expansions\n" "$c_green" "$c_reset"
+    pass=$((pass + 1))
+fi
+
+for bad in 'declare -A' 'readarray' 'mapfile'; do
+    if grep -q -- "$bad" "$SH_SCRIPT"; then
+        printf "  %sFAIL%s  workload-install.sh uses bash 4+ feature: %s\n" "$c_red" "$c_reset" "$bad"
+        fail=$((fail + 1))
+    else
+        printf "  %sPASS%s  no bash 4+ feature: %-12s\n" "$c_green" "$c_reset" "$bad"
+        pass=$((pass + 1))
+    fi
+done
+
+printf "  %sINFO%s  running under bash %s\n" "$c_yellow" "$c_reset" "${BASH_VERSION}"
+
+# --- 7. install path containing spaces ------------------------------------------
+#
+# Unquoted $DOTNET_INSTALL_DIR / $TMPDIR expansions word-split on a path with spaces.
+
+echo ""
+echo "-- space-containing install path --"
+
+SPACEDIR="$TMPROOT/dir with spaces/dotnet sdk"
+mkdir -p "$SPACEDIR"
+cat > "$SPACEDIR/dotnet" <<'STUB'
+#!/bin/bash
+case "$1" in
+    --version)   echo "10.0.100" ;;
+    --list-sdks) echo "10.0.100 [$(dirname "$0")/sdk]" ;;
+    workload)    exit 0 ;;
+    new)         exit 0 ;;
+    *)           exit 0 ;;
+esac
+STUB
+chmod +x "$SPACEDIR/dotnet"
+
+if curl -sSf -m 20 -o /dev/null https://api.nuget.org/v3/index.json 2>/dev/null; then
+    space_out="$(cd "$TMPROOT" && bash "$SH_SCRIPT" -d "$SPACEDIR" 2>&1)"; space_rc=$?
+    if [[ $space_rc -eq 0 ]] && [[ -f "$SPACEDIR/sdk-manifests/10.0.100/samsung.net.sdk.tizen/WorkloadManifest.json" ]]; then
+        printf "  %sPASS%s  installs into a path containing spaces\n" "$c_green" "$c_reset"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  install into space-containing path failed (exit %s)\n" "$c_red" "$c_reset" "$space_rc"
+        echo "$space_out" | tail -6 | sed 's/^/        | /'
+        fail=$((fail + 1))
+    fi
+else
+    printf "  %sSKIP%s  space-path install (no network)\n" "$c_yellow" "$c_reset"
+fi
+
+# --- 8. transport failure must fail closed --------------------------------------
+#
+# A failed/empty version query must take the fallback path and, when that yields
+# nothing, fail - never proceed with an empty version.
+
+echo ""
+echo "-- transport failure fails closed --"
+
+FAKEHOME="$TMPROOT/nonet"
+mkdir -p "$FAKEHOME"
+cat > "$FAKEHOME/dotnet" <<'STUB'
+#!/bin/bash
+case "$1" in
+    --version)   echo "99.0.100" ;;
+    --list-sdks) echo "99.0.100 [$(dirname "$0")/sdk]" ;;
+    *)           exit 0 ;;
+esac
+STUB
+chmod +x "$FAKEHOME/dotnet"
+# Force every curl to fail by pointing at an unroutable proxy.
+nonet_out="$(cd "$TMPROOT" && ALL_PROXY="http://127.0.0.1:9" HTTPS_PROXY="http://127.0.0.1:9" \
+             bash "$SH_SCRIPT" -d "$FAKEHOME" 2>&1)"; nonet_rc=$?
+if [[ $nonet_rc -ne 0 ]] && ! grep -q "^DONE$" <<< "$nonet_out"; then
+    printf "  %sPASS%s  unreachable feed -> non-zero exit, no DONE\n" "$c_green" "$c_reset"
+    pass=$((pass + 1))
+else
+    printf "  %sFAIL%s  unreachable feed -> exit %s (must fail closed)\n" "$c_red" "$c_reset" "$nonet_rc"
+    echo "$nonet_out" | tail -6 | sed 's/^/        | /'
+    fail=$((fail + 1))
+fi
+
 echo ""
 echo "============= install-failure summary ============="
 echo "  passed: $pass"

--- a/workload/scripts/test-install-failure.sh
+++ b/workload/scripts/test-install-failure.sh
@@ -411,6 +411,54 @@ PSEOF
     done
 fi
 
+# --- 11. explicit -Version "" must have no side effects ------------------------
+#
+# An explicit empty/whitespace -Version does NOT equal "<latest>", so it bypassed the
+# resolution-and-validation block entirely, reached the manifest REMOVAL, and produced a
+# versionless NuGet URL - and the v2 package endpoint serves the LATEST package for such a
+# URL. The gate is now unconditional, before any removal, URL construction or download.
+
+if command -v pwsh >/dev/null 2>&1 && [[ -f "$PS1_SCRIPT" ]]; then
+    echo ""
+    echo "-- explicit empty -Version has no side effects --"
+
+    EVDIR="$TMPROOT/emptyver"
+    mkdir -p "$EVDIR"
+    cat > "$EVDIR/dotnet" <<'STUB'
+#!/bin/bash
+case "$1" in
+    --version)   echo "10.0.100" ;;
+    --list-sdks) echo "10.0.100 [$(dirname "$0")/sdk]" ;;
+    *)           echo "SIDE_EFFECT: dotnet $*" ;;
+esac
+STUB
+    chmod +x "$EVDIR/dotnet"
+
+    for arg in "" "   "; do
+        # Pre-seed an installed manifest so its removal would be detectable.
+        seeded="$EVDIR/sdk-manifests/10.0.100/samsung.net.sdk.tizen"
+        rm -rf "$EVDIR/sdk-manifests"; mkdir -p "$seeded"
+        echo '{"version":"SENTINEL","packs":{}}' > "$seeded/WorkloadManifest.json"
+
+        ev_out="$(pwsh -NoProfile -File "$PS1_SCRIPT" -d "$EVDIR" -Version "$arg" 2>&1)"; ev_rc=$?
+        label="$([[ -z "$arg" ]] && echo 'empty' || echo 'whitespace')"
+
+        if [[ $ev_rc -ne 0 ]] \
+           && grep -q "manifest version is required" <<< "$ev_out" \
+           && ! grep -q "SIDE_EFFECT" <<< "$ev_out" \
+           && grep -q "SENTINEL" "$seeded/WorkloadManifest.json"; then
+            printf "  %sPASS%s  -Version %-12s rejected; no download, no removal\n" "$c_green" "$c_reset" "'$arg'"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  -Version %-12s exit=%s (expected rejection with no side effects)\n" "$c_red" "$c_reset" "'$arg'" "$ev_rc"
+            grep -q "SENTINEL" "$seeded/WorkloadManifest.json" 2>/dev/null || echo "        | installed manifest was REMOVED"
+            grep -q "SIDE_EFFECT" <<< "$ev_out" && echo "        | dotnet was invoked"
+            echo "$ev_out" | tail -3 | sed 's/^/        | /'
+            fail=$((fail + 1))
+        fi
+    done
+fi
+
 echo ""
 echo "============= install-failure summary ============="
 echo "  passed: $pass"

--- a/workload/scripts/test-install-failure.sh
+++ b/workload/scripts/test-install-failure.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+# Exit-code regression test for the install scripts.
+#
+# Both installers used to swallow every per-SDK failure: install_tizenworkload returned
+# early on error, the caller ignored the result, and the script printed "DONE" and exited 0.
+# A CI job that pipes the script to bash therefore reported success even when nothing was
+# installed. These tests pin the corrected behaviour.
+#
+# Usage:
+#   bash workload/scripts/test-install-failure.sh
+#   make -C workload test-install-failure
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SH_SCRIPT="$SCRIPT_DIR/workload-install.sh"
+PS1_SCRIPT="$SCRIPT_DIR/workload-install.ps1"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+c_reset=$'\033[0m'; c_red=$'\033[31m'; c_green=$'\033[32m'; c_yellow=$'\033[33m'
+[[ -t 1 ]] || { c_reset=""; c_red=""; c_green=""; c_yellow=""; }
+
+pass=0; fail=0
+
+check() {
+    local name="$1" expected="$2" actual="$3" output="$4"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  %sPASS%s  %-52s exit=%s\n" "$c_green" "$c_reset" "$name" "$actual"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-52s exit=%s (expected %s)\n" "$c_red" "$c_reset" "$name" "$actual" "$expected"
+        echo "$output" | tail -6 | sed 's/^/        | /'
+        fail=$((fail + 1))
+    fi
+}
+
+# --- 1. missing dotnet install dir must fail ------------------------------------
+
+out="$(bash "$SH_SCRIPT" -d "$TMPROOT/does-not-exist" 2>&1)"; rc=$?
+check "sh: nonexistent --dotnet-install-dir" 1 "$rc" "$out"
+
+# --- 2. dotnet present but no manifest for the band must fail -------------------
+#
+# A stub dotnet reports an implausible SDK version. The band lookup finds nothing on
+# NuGet and nothing in the fallback version map, so install_tizenworkload must fail and
+# the script must exit non-zero instead of printing DONE.
+
+FAKE="$TMPROOT/fakedotnet"
+mkdir -p "$FAKE"
+cat > "$FAKE/dotnet" <<'STUB'
+#!/bin/bash
+case "$1" in
+    --version)    echo "99.0.100" ;;
+    --list-sdks)  echo "99.0.100 [$(dirname "$0")/sdk]" ;;
+    *)            exit 0 ;;
+esac
+STUB
+chmod +x "$FAKE/dotnet"
+
+if curl -sSf -m 20 -o /dev/null https://api.nuget.org/v3/index.json 2>/dev/null; then
+    out="$(cd "$TMPROOT" && bash "$SH_SCRIPT" -d "$FAKE" 2>&1)"; rc=$?
+    check "sh: unknown SDK band fails instead of printing DONE" 1 "$rc" "$out"
+
+    if grep -q "^DONE$" <<< "$out"; then
+        printf "  %sFAIL%s  %-52s\n" "$c_red" "$c_reset" "sh: must not print DONE on failure"
+        fail=$((fail + 1))
+    else
+        printf "  %sPASS%s  %-52s\n" "$c_green" "$c_reset" "sh: must not print DONE on failure"
+        pass=$((pass + 1))
+    fi
+else
+    printf "  %sSKIP%s  %-52s (no network)\n" "$c_yellow" "$c_reset" "sh: unknown SDK band"
+fi
+
+# --- 3. PowerShell parity ------------------------------------------------------
+
+if command -v pwsh >/dev/null 2>&1 && [[ -f "$PS1_SCRIPT" ]]; then
+    out="$(pwsh -NoProfile -File "$PS1_SCRIPT" -d "$TMPROOT/does-not-exist" 2>&1)"; rc=$?
+    check "ps1: nonexistent -DotnetInstallDir" 1 "$rc" "$out"
+else
+    printf "  %sSKIP%s  %-52s (pwsh unavailable)\n" "$c_yellow" "$c_reset" "ps1 parity"
+fi
+
+echo ""
+echo "============= install-failure summary ============="
+echo "  passed: $pass"
+echo "  failed: $fail"
+
+[[ $fail -eq 0 ]] || exit 1
+exit 0

--- a/workload/scripts/test-matrix.sh
+++ b/workload/scripts/test-matrix.sh
@@ -24,6 +24,14 @@ WORKLOAD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 DOTNET="${DOTNET:-dotnet}"
 TMPDIR="${TEST_MATRIX_TMP:-$WORKLOAD_DIR/.tmp/matrix}"
 ONLY="${TEST_MATRIX_ONLY:-}"
+SELF_TEST=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --self-test) SELF_TEST="1" ;;
+        *) echo "Unknown argument '$arg'"; exit 2 ;;
+    esac
+done
 
 # Matrix rows: "<TargetFramework>|<api-version>"
 #
@@ -63,24 +71,60 @@ fail()   { printf "  %sFAIL%s  %s\n" "$c_red"   "$c_reset" "$*"; }
 warn()   { printf "  %sWARN%s  %s\n" "$c_yellow" "$c_reset" "$*"; }
 skip()   { printf "  %sSKIP%s  %s\n" "$c_yellow" "$c_reset" "$*"; }
 
-# Major versions of the .NET SDKs visible to $DOTNET, e.g. "8 9 10".
+# Newest .NET SDK major visible to $DOTNET, e.g. "11".
 # Populated once, after the $DOTNET prerequisite check below.
-INSTALLED_SDK_MAJORS=""
+LATEST_SDK_MAJOR=""
 
-# sdk_supports <netver>   e.g. sdk_supports net11.0
-# An SDK can only build a TFM whose .NET major it ships, so a net11.0 row needs
-# an 11.x SDK. Returns non-zero when unavailable so the row can be skipped.
-sdk_supports() {
+# sdk_can_target <netver>   e.g. sdk_can_target net11.0
+# An SDK can build any TFM up to and including its own major (the .NET 10 SDK builds
+# net8.0/net9.0/net10.0 fine), so a row is only unbuildable when its .NET major is
+# NEWER than the newest installed SDK. Returns non-zero in that case so the row is
+# skipped rather than reported as a failure.
+sdk_can_target() {
     local netver="$1"
     local want="${netver#net}"; want="${want%%.*}"
-    local have
-    for have in $INSTALLED_SDK_MAJORS; do
-        [[ "$have" == "$want" ]] && return 0
-    done
-    return 1
+    [[ -n "$LATEST_SDK_MAJOR" ]] || return 0
+    [[ "$want" -le "$LATEST_SDK_MAJOR" ]]
 }
 
 # --- prerequisites ---------------------------------------------------------
+
+# --self-test exercises the row-selection logic without any dotnet install, so CI can
+# pin it in the cheap metadata job. A regression here is expensive but silent: an
+# over-strict check makes every row "skip", and the matrix reports success having
+# built nothing.
+if [[ -n "$SELF_TEST" ]]; then
+    st_pass=0; st_fail=0
+    # "<newest installed SDK major>|<row TFM>|<expected: run|skip>"
+    #
+    # An SDK builds its own major and every earlier one, so only rows NEWER than the
+    # installed SDK may be skipped.
+    for c in \
+        "10|net8.0-tizen10.0|run"  "10|net9.0-tizen10.0|run"  "10|net10.0-tizen11.0|run" \
+        "10|net11.0-tizen11.0|skip" "10|net12.0-tizen11.0|skip" \
+        "11|net8.0-tizen10.0|run"  "11|net9.0-tizen10.0|run"  "11|net11.0-tizen11.0|run" \
+        "11|net12.0-tizen11.0|skip" \
+        "9|net8.0-tizen10.0|run"   "9|net10.0-tizen10.0|skip"
+    do
+        IFS='|' read -r major tfm want <<< "$c"
+        LATEST_SDK_MAJOR="$major"
+        netver="${tfm%-tizen*}"
+        if sdk_can_target "$netver"; then got="run"; else got="skip"; fi
+        if [[ "$got" == "$want" ]]; then
+            printf "  %sPASS%s  sdk=%-3s %-22s -> %s\n" "$c_green" "$c_reset" "$major.x" "$tfm" "$got"
+            st_pass=$((st_pass + 1))
+        else
+            printf "  %sFAIL%s  sdk=%-3s %-22s -> %s (expected %s)\n" "$c_red" "$c_reset" "$major.x" "$tfm" "$got" "$want"
+            st_fail=$((st_fail + 1))
+        fi
+    done
+    echo ""
+    echo "============ test-matrix self-test summary ============"
+    echo "  passed: $st_pass"
+    echo "  failed: $st_fail"
+    [[ $st_fail -eq 0 ]] || exit 1
+    exit 0
+fi
 
 if ! command -v "$DOTNET" >/dev/null 2>&1; then
     log "ERROR: '$DOTNET' command not found."
@@ -97,9 +141,9 @@ fi
 
 mkdir -p "$TMPDIR"
 
-# Discover which .NET majors this dotnet can build for.
-INSTALLED_SDK_MAJORS="$("$DOTNET" --list-sdks 2>/dev/null | sed -E 's/^([0-9]+)\..*/\1/' | sort -un | tr '\n' ' ')"
-log "Installed .NET SDK majors: ${INSTALLED_SDK_MAJORS:-<none detected>}"
+# Discover the newest .NET major this dotnet can build for.
+LATEST_SDK_MAJOR="$("$DOTNET" --list-sdks 2>/dev/null | sed -E 's/^([0-9]+)\..*/\1/' | sort -un | tail -1)"
+log "Newest .NET SDK major: ${LATEST_SDK_MAJOR:-<none detected>}"
 
 # --- matrix loop -----------------------------------------------------------
 
@@ -122,8 +166,8 @@ for entry in "${MATRIX[@]}"; do
     log ""
     log "==> [$tfm] api-version=$apiver"
 
-    if ! sdk_supports "$netver"; then
-        skip "$tfm  (no ${netver} SDK installed; rerun with DOTNET_VERSION=<${netver#net} sdk>)"
+    if ! sdk_can_target "$netver"; then
+        skip "$tfm  (needs a ${netver#net}+ SDK; newest installed is ${LATEST_SDK_MAJOR}.x)"
         skip_count+=1
         skipped_rows+=("$tfm")
         continue

--- a/workload/scripts/test-matrix.sh
+++ b/workload/scripts/test-matrix.sh
@@ -52,12 +52,20 @@ done
 #   run against the .NET 10 band stays green. To exercise these rows:
 #       make test-matrix DOTNET_VERSION=11.0.100-preview.7.26381.103
 MATRIX=(
+    # net8.0: oldest .NET major still exercised, across every current platform band.
     "net8.0-tizen10.0|10"
     "net8.0-tizen10.1|10.1"
     "net8.0-tizen11.0|11"
+    # net9.0
     "net9.0-tizen10.0|10"
-    "net11.0-tizen11.0|11"
+    # net10.0: the current shipping band. Covered explicitly rather than implied by the
+    # SDK version used to run the matrix.
+    "net10.0-tizen10.0|10"
+    "net10.0-tizen10.1|10.1"
+    "net10.0-tizen11.0|11"
+    # net11.0: the band this branch adds.
     "net11.0-tizen10.0|10"
+    "net11.0-tizen11.0|11"
 )
 
 # --- helpers ---------------------------------------------------------------
@@ -232,6 +240,42 @@ for entry in "${MATRIX[@]}"; do
         failed_rows+=("$tfm:build")
     fi
 done
+
+# --- self-contained disposition --------------------------------------------
+#
+# Samsung.NETCore.App.Runtime.tizen is a placeholder pack with no runtime binaries, so a
+# self-contained Tizen publish cannot work. It must fail with the actionable TIZENSDK001
+# rather than a raw XmlException from ResolveRuntimePackAssets parsing RuntimeList.xml,
+# or an opaque NETSDK1083.
+if [[ -z "$ONLY" && $pass_count -gt 0 ]]; then
+    sc_dir="$TMPDIR/selfcontained"
+    log ""
+    log "==> [self-contained disposition]"
+    rm -rf "$sc_dir" && mkdir -p "$sc_dir"
+    # Reuse whichever row built successfully; any Tizen project will do.
+    src_row="$(find "$TMPDIR" -maxdepth 1 -name 'net*-tizen*' -type d | head -1)"
+    if [[ -n "$src_row" ]]; then
+        cp "$src_row/TizenApp1.csproj" "$src_row/tizen-manifest.xml" "$sc_dir/" 2>/dev/null
+        cp -r "$src_row"/*.cs "$sc_dir/" 2>/dev/null
+        sc_log="$sc_dir/selfcontained.log"
+        if "$DOTNET" build "$sc_dir" --nologo -p:SelfContained=true > "$sc_log" 2>&1; then
+            fail "self-contained build unexpectedly SUCCEEDED (no runtime is shipped)"
+            fail_count+=1
+            failed_rows+=("selfcontained:unexpected-success")
+        elif grep -q "TIZENSDK001" "$sc_log"; then
+            pass "self-contained rejected with TIZENSDK001"
+            pass_count+=1
+        elif grep -qiE "XmlException|multiple root" "$sc_log"; then
+            fail "self-contained produced a raw XML parse error - RuntimeList.xml is malformed"
+            grep -iE "XmlException|multiple root" "$sc_log" | head -2 | sed 's/^/      | /'
+            fail_count+=1
+            failed_rows+=("selfcontained:xmlexception")
+        else
+            warn "self-contained failed before reaching the Tizen guard (see $sc_log)"
+            grep -m2 "error" "$sc_log" | sed 's/^/      | /'
+        fi
+    fi
+fi
 
 # --- summary ---------------------------------------------------------------
 

--- a/workload/scripts/test-matrix.sh
+++ b/workload/scripts/test-matrix.sh
@@ -254,7 +254,11 @@ if [[ -z "$ONLY" && $pass_count -gt 0 ]]; then
     rm -rf "$sc_dir" && mkdir -p "$sc_dir"
     # Reuse whichever row built successfully; any Tizen project will do.
     src_row="$(find "$TMPDIR" -maxdepth 1 -name 'net*-tizen*' -type d | head -1)"
-    if [[ -n "$src_row" ]]; then
+    if [[ -z "$src_row" ]]; then
+        fail "self-contained disposition could not run (no built row to reuse)"
+        fail_count+=1
+        failed_rows+=("selfcontained:no-fixture")
+    else
         cp "$src_row/TizenApp1.csproj" "$src_row/tizen-manifest.xml" "$sc_dir/" 2>/dev/null
         cp -r "$src_row"/*.cs "$sc_dir/" 2>/dev/null
         sc_log="$sc_dir/selfcontained.log"
@@ -271,8 +275,13 @@ if [[ -z "$ONLY" && $pass_count -gt 0 ]]; then
             fail_count+=1
             failed_rows+=("selfcontained:xmlexception")
         else
-            warn "self-contained failed before reaching the Tizen guard (see $sc_log)"
-            grep -m2 "error" "$sc_log" | sed 's/^/      | /'
+            # Any other diagnostic is a FAILURE, not a warning. Self-contained has exactly one
+            # supported outcome; NETSDK1083 or anything else means the guard did not fire and
+            # the user gets an unactionable error.
+            fail "self-contained produced an unexpected diagnostic (expected TIZENSDK001)"
+            grep -m3 "error" "$sc_log" | sed 's/^/      | /'
+            fail_count+=1
+            failed_rows+=("selfcontained:unexpected-diagnostic")
         fi
     fi
 fi

--- a/workload/scripts/test-matrix.sh
+++ b/workload/scripts/test-matrix.sh
@@ -37,11 +37,19 @@ ONLY="${TEST_MATRIX_ONLY:-}"
 #   A single shared fixture can't build both eras, so they are excluded here.
 #   Add coverage in a follow-up by introducing a separate legacy fixture
 #   (e.g. workload/scripts/fixtures/legacy/) keyed off the row's TFM.
+#
+# NOTE on net11.0-*:
+#   .NET 11 is a preview SDK band. A row is SKIPPED (not failed) when the dotnet
+#   under test cannot build that .NET major, so the default `make test-matrix`
+#   run against the .NET 10 band stays green. To exercise these rows:
+#       make test-matrix DOTNET_VERSION=11.0.100-preview.7.26381.103
 MATRIX=(
     "net8.0-tizen10.0|10"
     "net8.0-tizen10.1|10.1"
     "net8.0-tizen11.0|11"
     "net9.0-tizen10.0|10"
+    "net11.0-tizen11.0|11"
+    "net11.0-tizen10.0|10"
 )
 
 # --- helpers ---------------------------------------------------------------
@@ -53,6 +61,24 @@ log()    { printf "%s\n" "$*"; }
 pass()   { printf "  %sPASS%s  %s\n" "$c_green" "$c_reset" "$*"; }
 fail()   { printf "  %sFAIL%s  %s\n" "$c_red"   "$c_reset" "$*"; }
 warn()   { printf "  %sWARN%s  %s\n" "$c_yellow" "$c_reset" "$*"; }
+skip()   { printf "  %sSKIP%s  %s\n" "$c_yellow" "$c_reset" "$*"; }
+
+# Major versions of the .NET SDKs visible to $DOTNET, e.g. "8 9 10".
+# Populated once, after the $DOTNET prerequisite check below.
+INSTALLED_SDK_MAJORS=""
+
+# sdk_supports <netver>   e.g. sdk_supports net11.0
+# An SDK can only build a TFM whose .NET major it ships, so a net11.0 row needs
+# an 11.x SDK. Returns non-zero when unavailable so the row can be skipped.
+sdk_supports() {
+    local netver="$1"
+    local want="${netver#net}"; want="${want%%.*}"
+    local have
+    for have in $INSTALLED_SDK_MAJORS; do
+        [[ "$have" == "$want" ]] && return 0
+    done
+    return 1
+}
 
 # --- prerequisites ---------------------------------------------------------
 
@@ -71,10 +97,15 @@ fi
 
 mkdir -p "$TMPDIR"
 
+# Discover which .NET majors this dotnet can build for.
+INSTALLED_SDK_MAJORS="$("$DOTNET" --list-sdks 2>/dev/null | sed -E 's/^([0-9]+)\..*/\1/' | sort -un | tr '\n' ' ')"
+log "Installed .NET SDK majors: ${INSTALLED_SDK_MAJORS:-<none detected>}"
+
 # --- matrix loop -----------------------------------------------------------
 
-declare -i pass_count=0 fail_count=0
+declare -i pass_count=0 fail_count=0 skip_count=0
 declare -a failed_rows=()
+declare -a skipped_rows=()
 
 for entry in "${MATRIX[@]}"; do
     tfm="${entry%%|*}"
@@ -84,12 +115,19 @@ for entry in "${MATRIX[@]}"; do
         continue
     fi
 
-    netver="${tfm%-tizen*}"      # net6.0 / net8.0 / net9.0
-    platver="${tfm##*-tizen}"    # 8.0 / 9.0 / 10.0 / 11.0
+    netver="${tfm%-tizen*}"      # net6.0 / net8.0 / net9.0 / net11.0
+    platver="${tfm##*-tizen}"    # 8.0 / 9.0 / 10.0 / 10.1 / 11.0
     rowdir="$TMPDIR/$tfm"
 
     log ""
     log "==> [$tfm] api-version=$apiver"
+
+    if ! sdk_supports "$netver"; then
+        skip "$tfm  (no ${netver} SDK installed; rerun with DOTNET_VERSION=<${netver#net} sdk>)"
+        skip_count+=1
+        skipped_rows+=("$tfm")
+        continue
+    fi
 
     rm -rf "$rowdir"
     mkdir -p "$rowdir"
@@ -157,6 +195,14 @@ log ""
 log "================ test-matrix summary ================"
 log "  passed:  $pass_count"
 log "  failed:  $fail_count"
+log "  skipped: $skip_count"
+
+if [[ $skip_count -gt 0 ]]; then
+    log "  skipped rows:"
+    for r in "${skipped_rows[@]}"; do
+        log "    - $r"
+    done
+fi
 
 if [[ $fail_count -gt 0 ]]; then
     log "  failed rows:"

--- a/workload/scripts/test-package-fallback.sh
+++ b/workload/scripts/test-package-fallback.sh
@@ -74,7 +74,7 @@ CASES=(
 for case in "${CASES[@]}"; do
     IFS='|' read -r tfv tpv want_present want_absent <<< "$case"
 
-    out="$("$DOTNET" msbuild "$TMPDIR/probe.proj" -t:Probe -nologo -v:m \
+    out="$("$DOTNET" msbuild "$TMPDIR/probe.proj" -t:Probe -nologo -v:m -nodereuse:false \
             -p:TargetFrameworkVersion="$tfv" -p:TargetPlatformVersion="$tpv" 2>&1 \
             | grep -o 'RESULT|.*' | head -1)"
     list=";${out#RESULT|};"
@@ -125,9 +125,10 @@ echo "-- selection priority / atomicity --"
 TASK_PROJ="$WORKLOAD_DIR/src/Samsung.Tizen.Build.Tasks/Samsung.Tizen.Build.Tasks.csproj"
 TASK_DLL="$WORKLOAD_DIR/src/Samsung.Tizen.Build.Tasks/bin/Release/netstandard2.0/Samsung.Tizen.Build.Tasks.dll"
 
-if [[ ! -f "$TASK_DLL" ]]; then
-    "$DOTNET" build "$TASK_PROJ" -c Release --nologo -v:q >/dev/null 2>&1 || true
-fi
+# Always rebuild: a stale DLL would let the suite validate code that is no longer the
+# source of truth. MSBuild node reuse is disabled everywhere below for the same reason -
+# a persistent node caches the loaded task assembly across invocations.
+"$DOTNET" build "$TASK_PROJ" -c Release --nologo -v:q -nodereuse:false >/dev/null 2>&1 || true
 
 # "<label>|<priority list>|<dirs to create>|<expected winner>|<dirs that get Extras.dll>"
 #
@@ -190,7 +191,7 @@ else
 </Project>
 PROJEOF
 
-            out="$("$DOTNET" msbuild "$TMPDIR/fixup$ci.proj" -t:Probe -nologo -v:m 2>&1 | grep -o 'ADDED|.*' | head -1)"
+            out="$("$DOTNET" msbuild "$TMPDIR/fixup$ci.proj" -t:Probe -nologo -v:m -nodereuse:false 2>&1 | grep -o 'ADDED|.*' | head -1)"
             added="${out#ADDED|}"
             bad=0; seen=""
             [[ -z "$added" ]] && bad=1
@@ -209,6 +210,69 @@ PROJEOF
                 fail=$((fail + 1))
             fi
         done
+    done
+fi
+
+# --- final asset set: no netstandard remnants --------------------------------
+#
+# Selecting one fallback TFM is not enough. The task must remove the package's ENTIRE
+# netstandard asset group, not just the files the fallback happens to share a name with -
+# otherwise the leftover netstandard DLLs stay in the reference set and the build mixes
+# platform-specific and netstandard assemblies from the SAME package.
+#
+# Fixture: netstandard2.0 carries A.dll AND B.dll, but the winning TFM carries only A.dll.
+# The final set (originals minus removed, plus added) must contain NO netstandard asset.
+
+echo ""
+echo "-- final asset set has no netstandard remnants --"
+
+if [[ ! -f "$TASK_DLL" ]]; then
+    printf "  %sSKIP%s  task assembly unavailable\n" "$c_yellow" "$c_reset"
+else
+    for order in forward reverse; do
+        pkgroot="$TMPDIR/remnant-$order/lib"
+        rm -rf "$pkgroot"; mkdir -p "$pkgroot/netstandard2.0"
+        printf 'ns' > "$pkgroot/netstandard2.0/A.dll"
+        printf 'ns' > "$pkgroot/netstandard2.0/B.dll"
+        if [[ "$order" == "forward" ]]; then dirs="net9.0-tizen9.0 net6.0-tizen8.0"; else dirs="net6.0-tizen8.0 net9.0-tizen9.0"; fi
+        for d in $dirs; do mkdir -p "$pkgroot/$d"; done
+        # Winner carries ONLY A.dll; B.dll exists solely as a netstandard asset.
+        printf 'net9.0-tizen9.0' > "$pkgroot/net9.0-tizen9.0/A.dll"
+        printf 'net6.0-tizen8.0' > "$pkgroot/net6.0-tizen8.0/A.dll"
+        printf 'net6.0-tizen8.0' > "$pkgroot/net6.0-tizen8.0/B.dll"
+
+        cat > "$TMPDIR/remnant-$order.proj" <<PROJEOF
+<Project>
+  <UsingTask TaskName="Samsung.Tizen.Build.Tasks.FixupNuGetReferences" AssemblyFile="$TASK_DLL" />
+  <Target Name="Probe">
+    <ItemGroup>
+      <CopyLocal Include="$pkgroot/netstandard2.0/A.dll" />
+      <CopyLocal Include="$pkgroot/netstandard2.0/B.dll" />
+    </ItemGroup>
+    <Samsung.Tizen.Build.Tasks.FixupNuGetReferences
+        PackageTargetFallback="net9.0-tizen9.0;net6.0-tizen8.0"
+        CopyLocalItems="@(CopyLocal)">
+      <Output TaskParameter="AssembliesToAdd" ItemName="Added" />
+      <Output TaskParameter="AssembliesToRemove" ItemName="Removed" />
+    </Samsung.Tizen.Build.Tasks.FixupNuGetReferences>
+    <ItemGroup>
+      <Final Include="@(CopyLocal)" Exclude="@(Removed)" />
+      <Final Include="@(Added)" />
+    </ItemGroup>
+    <Message Importance="high" Text="FINAL|@(Final)" />
+  </Target>
+</Project>
+PROJEOF
+
+        out="$("$DOTNET" msbuild "$TMPDIR/remnant-$order.proj" -t:Probe -nologo -v:m -nodereuse:false 2>&1 | grep -o 'FINAL|.*' | head -1)"
+        final="${out#FINAL|}"
+        if [[ -n "$final" ]] && ! grep -q 'netstandard2\.0' <<< "$final"; then
+            printf "  %sPASS%s  [%-7s] final set free of netstandard assets\n" "$c_green" "$c_reset" "$order"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  [%-7s] netstandard asset survived: %s\n" "$c_red" "$c_reset" "$order" "${final:-<none>}"
+            fail=$((fail + 1))
+        fi
     done
 fi
 

--- a/workload/scripts/test-package-fallback.sh
+++ b/workload/scripts/test-package-fallback.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+# Evaluation test for PackageTargetFallback compatibility filtering.
+#
+# FixupNuGetReferences matches a package's lib/<name>/ sibling directories against
+# PackageTargetFallback by NAME ONLY - it performs no compatibility check of its own.
+# An unfiltered cross-product therefore lets a net6.0-tizen8.0 build silently pick up
+# net6.0-tizen11.0 (newer platform) or net11.0-tizen8.0 (newer .NET) assets.
+#
+# This test extracts the real filtering block from the shipped
+# Samsung.Tizen.Sdk.NuGet.targets (between the BEGIN/END TIZEN PACKAGE FALLBACK markers)
+# and evaluates it, asserting both that compatible entries are present and - the point of
+# the exercise - that incompatible ones are ABSENT.
+#
+# Usage:
+#   bash workload/scripts/test-package-fallback.sh
+#   make -C workload test-package-fallback
+#
+
+set -uo pipefail
+
+WORKLOAD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TARGETS="$WORKLOAD_DIR/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets"
+DOTNET="${DOTNET:-dotnet}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+c_reset=$'\033[0m'; c_red=$'\033[31m'; c_green=$'\033[32m'; c_yellow=$'\033[33m'
+[[ -t 1 ]] || { c_reset=""; c_red=""; c_green=""; c_yellow=""; }
+
+if ! command -v "$DOTNET" >/dev/null 2>&1; then
+    echo "  ${c_yellow}SKIP${c_reset}  '$DOTNET' not found; cannot evaluate MSBuild expressions."
+    exit 0
+fi
+
+BLOCK="$(sed -n '/BEGIN TIZEN PACKAGE FALLBACK/,/END TIZEN PACKAGE FALLBACK/p' "$TARGETS" \
+         | sed -e '1d' -e '$d')"
+if [[ -z "$BLOCK" ]]; then
+    echo "ERROR: TIZEN PACKAGE FALLBACK markers not found in $TARGETS."
+    echo "       Keep the markers intact so this test exercises shipped code."
+    exit 2
+fi
+
+{
+    echo '<Project>'
+    echo "$BLOCK"
+    echo '  <Target Name="Probe">'
+    echo '    <Message Importance="high" Text="RESULT|$(PackageTargetFallback)" />'
+    echo '  </Target>'
+    echo '</Project>'
+} > "$TMPDIR/probe.proj"
+
+pass=0; fail=0
+
+# "<TFV>|<TPV>|<must be present, comma-sep>|<must be ABSENT, comma-sep>"
+CASES=(
+    # Building for the lowest supported platform: nothing newer may leak in.
+    "v6.0|8.0|net6.0-tizen8.0,tizen80|net6.0-tizen9.0,net6.0-tizen10.0,net6.0-tizen11.0,net8.0-tizen8.0,net11.0-tizen11.0,tizen90,tizen10.0"
+    # Newer .NET, old platform: platform siblings above 8.0 must stay out.
+    "v11.0|8.0|net11.0-tizen8.0,net6.0-tizen8.0,tizen80|net11.0-tizen9.0,net6.0-tizen11.0,net11.0-tizen11.0,tizen90"
+    # Old .NET, newest platform: .NET majors above 6.0 must stay out.
+    "v6.0|11.0|net6.0-tizen11.0,net6.0-tizen8.0,tizen10.0|net8.0-tizen11.0,net11.0-tizen11.0,net9.0-tizen10.0"
+    # The primary target: everything at or below is fair game.
+    "v11.0|11.0|net11.0-tizen11.0,net6.0-tizen8.0,net8.0-tizen10.0,tizen40|"
+    # Mid-range combination.
+    "v9.0|10.0|net9.0-tizen10.0,net8.0-tizen9.0,tizen10.0|net10.0-tizen10.0,net11.0-tizen11.0,net9.0-tizen10.1,net9.0-tizen11.0"
+    # 10.1 must not admit 11.0, and 10.1 itself is available at 10.1.
+    "v10.0|10.1|net10.0-tizen10.1,net10.0-tizen10.0|net10.0-tizen11.0,net11.0-tizen10.1"
+)
+
+for case in "${CASES[@]}"; do
+    IFS='|' read -r tfv tpv want_present want_absent <<< "$case"
+
+    out="$("$DOTNET" msbuild "$TMPDIR/probe.proj" -t:Probe -nologo -v:m \
+            -p:TargetFrameworkVersion="$tfv" -p:TargetPlatformVersion="$tpv" 2>&1 \
+            | grep -o 'RESULT|.*' | head -1)"
+    list=";${out#RESULT|};"
+    list="${list// /}"
+
+    label="net${tfv#v}-tizen${tpv}"
+    row_ok=1
+    detail=""
+
+    presents=(); absents=()
+    [[ -n "$want_present" ]] && IFS=',' read -ra presents <<< "$want_present"
+    [[ -n "$want_absent"  ]] && IFS=',' read -ra absents  <<< "$want_absent"
+
+    for e in "${presents[@]+"${presents[@]}"}"; do
+        [[ -z "$e" || "$e" == *_SKIP ]] && continue
+        if [[ "$list" != *";$e;"* ]]; then row_ok=0; detail="$detail missing:$e"; fi
+    done
+
+    for e in "${absents[@]+"${absents[@]}"}"; do
+        [[ -z "$e" ]] && continue
+        if [[ "$list" == *";$e;"* ]]; then row_ok=0; detail="$detail LEAKED:$e"; fi
+    done
+
+    if [[ $row_ok -eq 1 ]]; then
+        printf "  %sPASS%s  %-22s\n" "$c_green" "$c_reset" "$label"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-22s%s\n" "$c_red" "$c_reset" "$label" "$detail"
+        printf "        list: %s\n" "${out#RESULT|}"
+        fail=$((fail + 1))
+    fi
+done
+
+echo ""
+echo "=========== package-fallback summary ==========="
+echo "  passed: $pass"
+echo "  failed: $fail"
+
+[[ $fail -eq 0 ]] || exit 1
+exit 0

--- a/workload/scripts/test-package-fallback.sh
+++ b/workload/scripts/test-package-fallback.sh
@@ -108,6 +108,110 @@ for case in "${CASES[@]}"; do
     fi
 done
 
+# --- selection priority + atomicity ------------------------------------------
+#
+# PackageTargetFallback is an ORDERED preference list, but FixupNuGetReferences used to add
+# every matching directory to an unordered HashSet (populated in FILESYSTEM enumeration
+# order) and then take assemblies first-wins across all of them. Two consequences:
+#   * the declared priority was ignored whenever it disagreed with directory order, and
+#   * assemblies could be MIXED across TFMs within one package.
+#
+# The cases below are chosen so alphabetical directory order DISAGREES with the declared
+# priority - otherwise the old implementation passes by luck.
+
+echo ""
+echo "-- selection priority / atomicity --"
+
+TASK_PROJ="$WORKLOAD_DIR/src/Samsung.Tizen.Build.Tasks/Samsung.Tizen.Build.Tasks.csproj"
+TASK_DLL="$WORKLOAD_DIR/src/Samsung.Tizen.Build.Tasks/bin/Release/netstandard2.0/Samsung.Tizen.Build.Tasks.dll"
+
+if [[ ! -f "$TASK_DLL" ]]; then
+    "$DOTNET" build "$TASK_PROJ" -c Release --nologo -v:q >/dev/null 2>&1 || true
+fi
+
+# "<label>|<priority list>|<dirs to create>|<expected winner>|<dirs that get Extras.dll>"
+#
+# 'priority' mirrors what the SDK emits for the project being built (highest first).
+# Alphabetically net6.0-tizen8.0 sorts BEFORE net9.0-tizen9.0, so a filesystem-ordered
+# implementation picks the wrong one here.
+PRIORITY_CASES=(
+    "priority beats dir order|net9.0-tizen9.0;net6.0-tizen8.0|net9.0-tizen9.0 net6.0-tizen8.0|net9.0-tizen9.0|net9.0-tizen9.0 net6.0-tizen8.0"
+    "no mixing across TFMs|net9.0-tizen9.0;net6.0-tizen8.0|net9.0-tizen9.0 net6.0-tizen8.0|net9.0-tizen9.0|net6.0-tizen8.0"
+    "mid-priority wins|net8.0-tizen10.0;net6.0-tizen8.0|net8.0-tizen10.0 net6.0-tizen8.0|net8.0-tizen10.0|net8.0-tizen10.0 net6.0-tizen8.0"
+)
+
+if [[ ! -f "$TASK_DLL" ]]; then
+    printf "  %sSKIP%s  task assembly unavailable (build failed)\n" "$c_yellow" "$c_reset"
+else
+    ci=0
+    for case in "${PRIORITY_CASES[@]}"; do
+        IFS='|' read -r label priority dirs want extras <<< "$case"
+
+        # Directory enumeration order is filesystem-dependent (observed here as reverse
+        # creation order). Rather than depend on it, run each case in BOTH creation orders:
+        # whichever way the filesystem enumerates, one of the two runs presents a
+        # lower-priority directory first. An implementation that follows enumeration order
+        # instead of the declared priority must fail at least one of them.
+        for order in forward reverse; do
+            ci=$((ci + 1))
+            pkgroot="$TMPDIR/pkg$ci/lib"
+            rm -rf "$pkgroot"; mkdir -p "$pkgroot/netstandard2.0"
+            printf 'netstandard2.0' > "$pkgroot/netstandard2.0/Contoso.dll"
+            printf 'netstandard2.0' > "$pkgroot/netstandard2.0/Contoso.Extras.dll"
+
+            if [[ "$order" == "forward" ]]; then
+                ordered="$dirs"
+            else
+                ordered="$(echo "$dirs" | tr ' ' '\n' | sed '1!G;h;$!d' | tr '\n' ' ')"
+            fi
+
+            for d in $ordered; do
+                [[ -z "$d" ]] && continue
+                mkdir -p "$pkgroot/$d"
+                printf '%s' "$d" > "$pkgroot/$d/Contoso.dll"
+                case " $extras " in *" $d "*) printf '%s' "$d" > "$pkgroot/$d/Contoso.Extras.dll" ;; esac
+            done
+
+            cat > "$TMPDIR/fixup$ci.proj" <<PROJEOF
+<Project>
+  <UsingTask TaskName="Samsung.Tizen.Build.Tasks.FixupNuGetReferences" AssemblyFile="$TASK_DLL" />
+  <Target Name="Probe">
+    <ItemGroup>
+      <CopyLocal Include="$pkgroot/netstandard2.0/Contoso.dll" />
+      <CopyLocal Include="$pkgroot/netstandard2.0/Contoso.Extras.dll" />
+    </ItemGroup>
+    <Samsung.Tizen.Build.Tasks.FixupNuGetReferences
+        PackageTargetFallback="$priority"
+        CopyLocalItems="@(CopyLocal)">
+      <Output TaskParameter="AssembliesToAdd" ItemName="Added" />
+    </Samsung.Tizen.Build.Tasks.FixupNuGetReferences>
+    <Message Importance="high" Text="ADDED|@(Added)" />
+  </Target>
+</Project>
+PROJEOF
+
+            out="$("$DOTNET" msbuild "$TMPDIR/fixup$ci.proj" -t:Probe -nologo -v:m 2>&1 | grep -o 'ADDED|.*' | head -1)"
+            added="${out#ADDED|}"
+            bad=0; seen=""
+            [[ -z "$added" ]] && bad=1
+            IFS=';' read -ra items <<< "$added"
+            for a in "${items[@]+"${items[@]}"}"; do
+                [[ -z "$a" ]] && continue
+                tfmdir="$(basename "$(dirname "$a")")"
+                seen="$seen $tfmdir"
+                [[ "$tfmdir" != "$want" ]] && bad=1
+            done
+            if [[ $bad -eq 0 ]]; then
+                printf "  %sPASS%s  %-28s [%-7s] all from %s\n" "$c_green" "$c_reset" "$label" "$order" "$want"
+                pass=$((pass + 1))
+            else
+                printf "  %sFAIL%s  %-28s [%-7s] expected only %s, saw:%s\n" "$c_red" "$c_reset" "$label" "$order" "$want" "${seen:- <none>}"
+                fail=$((fail + 1))
+            fi
+        done
+    done
+fi
+
 echo ""
 echo "=========== package-fallback summary ==========="
 echo "  passed: $pass"

--- a/workload/scripts/test-release-workflow.sh
+++ b/workload/scripts/test-release-workflow.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+# Semantic checks for .github/workflows/release-workload.yml.
+#
+# The release workflow cannot be executed here, so these assertions pin the ordering and
+# guard conditions that make a release safe and RETRYABLE:
+#
+#   * the version bump is persisted only AFTER the build and artifact verification, so a
+#     failed release does not leave the branch bumped and therefore unretryable
+#     (the retry would compute OLD == NEW);
+#   * OLD == NEW resumes rather than aborts;
+#   * a reference-only run mutates nothing;
+#   * the release tag targets the commit that carries the released Versions.props;
+#   * pushes use the verified staging directory, not a glob over the workspace;
+#   * re-creating an existing tag is a no-op.
+#
+# Usage:
+#   bash workload/scripts/test-release-workflow.sh
+#   make -C workload test-release-workflow
+#
+
+set -uo pipefail
+
+WORKLOAD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WF="$WORKLOAD_DIR/../.github/workflows/release-workload.yml"
+
+c_reset=$'\033[0m'; c_red=$'\033[31m'; c_green=$'\033[32m'
+[[ -t 1 ]] || { c_reset=""; c_red=""; c_green=""; }
+
+pass=0; fail=0
+
+if [[ ! -f "$WF" ]]; then
+    echo "ERROR: $WF not found."
+    exit 2
+fi
+
+assert() {
+    local label="$1" cond="$2"
+    if [[ "$cond" == "1" ]]; then
+        printf "  %sPASS%s  %s\n" "$c_green" "$c_reset" "$label"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %s\n" "$c_red" "$c_reset" "$label"
+        fail=$((fail + 1))
+    fi
+}
+
+line_of() { grep -n -- "$1" "$WF" | head -1 | cut -d: -f1; }
+
+BUILD_LN=$(line_of "    - name: Build")
+STAGE_LN=$(line_of "    - name: Stage and verify packages")
+COMMIT_LN=$(line_of "    - name: Commit and push the version bump")
+PUSH_LN=$(line_of "    - name: Push Manifest/SDK/Runtime packs")
+REL_LN=$(line_of "    - name: Create GitHub Release")
+
+# --- ordering ---------------------------------------------------------------
+
+assert "build runs before staging" \
+    "$([[ -n "$BUILD_LN" && -n "$STAGE_LN" && "$BUILD_LN" -lt "$STAGE_LN" ]] && echo 1 || echo 0)"
+
+assert "version bump is persisted AFTER staging verification" \
+    "$([[ -n "$STAGE_LN" && -n "$COMMIT_LN" && "$STAGE_LN" -lt "$COMMIT_LN" ]] && echo 1 || echo 0)"
+
+assert "version bump is persisted BEFORE packages are pushed" \
+    "$([[ -n "$COMMIT_LN" && -n "$PUSH_LN" && "$COMMIT_LN" -lt "$PUSH_LN" ]] && echo 1 || echo 0)"
+
+assert "release tag is created last" \
+    "$([[ -n "$PUSH_LN" && -n "$REL_LN" && "$PUSH_LN" -lt "$REL_LN" ]] && echo 1 || echo 0)"
+
+# --- retryability / non-mutation --------------------------------------------
+
+assert "OLD == NEW resumes instead of aborting" \
+    "$(grep -q 'Resuming release of' "$WF" && ! grep -q 'ERROR: computed next == current' "$WF" && echo 1 || echo 0)"
+
+assert "reference-only run is non-mutating" \
+    "$(grep -q 'Reference-only run: leaving TizenWorkloadVersion' "$WF" && echo 1 || echo 0)"
+
+assert "commit step is skipped when nothing was mutated" \
+    "$(grep -q 'steps.bump.outputs.mutated' "$WF" && echo 1 || echo 0)"
+
+assert "build is not continue-on-error" \
+    "$(awk -v s="$BUILD_LN" -v e="$STAGE_LN" 'NR>s && NR<e && /continue-on-error/ {found=1} END{exit !found}' "$WF" && echo 0 || echo 1)"
+
+# --- correctness of what gets published -------------------------------------
+
+assert "tag targets the released commit, not just the branch ref" \
+    "$(grep -q 'steps.commit.outputs.release_sha' "$WF" && echo 1 || echo 0)"
+
+assert "release notes use the staged manifest id" \
+    "$(grep -q 'steps.stage.outputs.manifest_id' "$WF" && echo 1 || echo 0)"
+
+assert "release notes do not recompute the band with \${SDK%%-*}" \
+    "$(grep -q 'BAND="\${SDK%%-\*}"' "$WF" && echo 0 || echo 1)"
+
+assert "pushes come from the verified staging directory" \
+    "$(grep -q 'steps.stage.outputs.staging }}/Samsung.NET.Sdk.Tizen.Manifest-' "$WF" && echo 1 || echo 0)"
+
+assert "no push globs the raw workspace output directory" \
+    "$(grep -q 'dotnet nuget push ./workload/out/' "$WF" && echo 0 || echo 1)"
+
+assert "existing release tag is a no-op (resumable)" \
+    "$(grep -q 'already exists; skipping creation' "$WF" && echo 1 || echo 0)"
+
+echo ""
+echo "=========== release-workflow summary ==========="
+echo "  passed: $pass"
+echo "  failed: $fail"
+
+[[ $fail -eq 0 ]] || exit 1
+exit 0

--- a/workload/scripts/test-release-workflow.sh
+++ b/workload/scripts/test-release-workflow.sh
@@ -140,6 +140,39 @@ assert "publication completeness is verified before tagging" \
 assert "every push is idempotent (--skip-duplicate)" \
     "$([[ "$(grep -c 'skip-duplicate' "$WF")" -ge 3 ]] && echo 1 || echo 0)"
 
+# --- resume set must match what the workflow actually publishes --------------
+#
+# release-state.py decides whether a version is fully published. If a pack is added to the
+# push steps but not to that list, a version missing it would be reported "published", get
+# tagged, and never be completed - the exact failure this machinery exists to prevent.
+
+assert "band is computed in exactly one place" \
+    "$([[ "$(grep -c 'compute_target_version_band' "$WF")" -eq 1 ]] && echo 1 || echo 0)"
+
+STATE_PKGS="$(python3 - "$WORKLOAD_DIR/scripts/release-state.py" <<'PYEOF'
+import re, sys
+src = open(sys.argv[1], encoding="utf-8").read()
+block = re.search(r"VERSIONED_PACKAGE_SUFFIXES = \[(.*?)\]", src, re.S).group(1)
+print("\n".join(sorted(re.findall(r'"([^"]+)"', block))))
+PYEOF
+)"
+
+# Package globs the workflow pushes under the workload version (excludes the Ref packs,
+# which are versioned by TizenFX and gated by release_reference).
+PUSHED="$(grep -oE '\$pattern|for pattern in [^;]*' "$WF" | sed -n 's/^for pattern in //p' | tr ' ' '\n' | sed '/^$/d' | sort -u)"
+
+norm() { sed 's/^Samsung\.NETCore\.App\.Runtime$/Samsung.NETCore.App.Runtime.tizen/' ; }
+missing_from_state=""
+while read -r pkg; do
+    [[ -z "$pkg" ]] && continue
+    canonical="$(echo "$pkg" | norm)"
+    grep -Fqx "$canonical" <<< "$STATE_PKGS" || missing_from_state="$missing_from_state $canonical"
+done <<< "$PUSHED"
+
+assert "every pushed pack is tracked by release-state.py" \
+    "$([[ -z "$missing_from_state" ]] && echo 1 || echo 0)"
+[[ -n "$missing_from_state" ]] && echo "        untracked:$missing_from_state"
+
 # --- failure injection against the real state script -------------------------
 #
 # Simulates a release interrupted at each step, using a local file:// feed, and asserts the

--- a/workload/scripts/test-release-workflow.sh
+++ b/workload/scripts/test-release-workflow.sh
@@ -86,7 +86,7 @@ assert "ownership is claimed via an atomic reservation ref" \
     "$(grep -q 'refs/tizen-release/v' "$WF" && echo 1 || echo 0)"
 
 assert "a foreign reservation aborts the run" \
-    "$(grep -q 'already reserved by another release' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'already reserved by a release with different inputs' "$WF" && echo 1 || echo 0)"
 
 assert "releases are serialized by a concurrency group" \
     "$(grep -q 'group: tizen-workload-release' "$WF" && echo 1 || echo 0)"
@@ -118,7 +118,7 @@ assert "reference-only run is non-mutating" \
     "$(grep -q 'Reference-only run: leaving TizenWorkloadVersion' "$WF" && echo 1 || echo 0)"
 
 assert "a resumed run rebuilds from the reservation's commit" \
-    "$(grep -q 'no reservation ref exists' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'print-field sha' "$WF" && grep -q 'release_sha=\$RESUME_SHA' "$WF" && echo 1 || echo 0)"
 
 assert "build is not continue-on-error" \
     "$(awk -v s="$BUILD_LN" -v e="$STAGE_LN" 'NR>s && NR<e && /continue-on-error/ {found=1} END{exit !found}' "$WF" && echo 0 || echo 1)"
@@ -126,7 +126,7 @@ assert "build is not continue-on-error" \
 # --- correctness of what gets published -------------------------------------
 
 assert "tag targets the reserved release commit" \
-    "$(grep -q 'target "\${{ steps.bump.outputs.release_sha }}"' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'SHA="\${{ steps.bump.outputs.release_sha }}"' "$WF" && grep -q -- '--target "\$SHA"' "$WF" && echo 1 || echo 0)"
 
 assert "release notes use the staged manifest id" \
     "$(grep -q 'steps.stage.outputs.manifest_id' "$WF" && echo 1 || echo 0)"
@@ -141,7 +141,7 @@ assert "no push globs the raw workspace output directory" \
     "$(grep -q 'dotnet nuget push ./workload/out/' "$WF" && echo 0 || echo 1)"
 
 assert "existing release tag is a no-op (resumable)" \
-    "$(grep -q 'already exists; skipping creation' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'already exists at the reserved commit' "$WF" && echo 1 || echo 0)"
 
 # --- partial-publication resume ---------------------------------------------
 
@@ -150,13 +150,13 @@ COMPANION_PUSH_LN=$(line_of "    - name: Push SDK/Runtime/Templates packs")
 VERIFY_LN=$(line_of "    - name: Verify publication is complete")
 
 assert "publication state is inspected before advancing the version" \
-    "$(grep -q 'release-state.py --version "\$OLD"' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'release-state.py --version "\$V"' "$WF" && echo 1 || echo 0)"
 
 assert "a partially published version is resumed, never advanced" \
-    "$(grep -q 'is partially published' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'is unfinished (state=\$STATE' "$WF" && grep -q 'NEW=\$(python3 scripts/next-workload-version.py)' "$WF" && echo 1 || echo 0)"
 
 assert "a published-but-untagged version is resumed to finish the tag" \
-    "$(grep -q 'is published but untagged' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'STATE" = "published" ] && \[ "\$RELEASED" = "true" \]' "$WF" && echo 1 || echo 0)"
 
 assert "companion packs are pushed BEFORE the manifest" \
     "$([[ -n "$COMPANION_PUSH_LN" && -n "$MANIFEST_PUSH_LN" && "$COMPANION_PUSH_LN" -lt "$MANIFEST_PUSH_LN" ]] && echo 1 || echo 0)"
@@ -189,6 +189,12 @@ PYEOF
 PUSHED="$(grep -oE '\$pattern|for pattern in [^;]*' "$WF" | sed -n 's/^for pattern in //p' | tr ' ' '\n' | sed '/^$/d' | sort -u)"
 
 norm() { sed 's/^Samsung\.NETCore\.App\.Runtime$/Samsung.NETCore.App.Runtime.tizen/' ; }
+
+# The reservation payload records the authoritative package set for a release, so it is a
+# THIRD place the list lives. All three must agree.
+RESERVED_PKGS="$(grep -oE 'PACKAGES="[^"]*"' "$WF" | head -1 | sed 's/PACKAGES="//;s/"$//' \
+    | tr ',' '\n' | sed 's/\$MANIFEST_ID//' | sed '/^$/d' | sort -u)"
+
 missing_from_state=""
 while read -r pkg; do
     [[ -z "$pkg" ]] && continue
@@ -200,7 +206,163 @@ assert "every pushed pack is tracked by release-state.py" \
     "$([[ -z "$missing_from_state" ]] && echo 1 || echo 0)"
 [[ -n "$missing_from_state" ]] && echo "        untracked:$missing_from_state"
 
-# --- failure injection against the real state script -------------------------
+# The reverse direction matters just as much and was missing. A package listed in
+# release-state.py that the workflow never pushes can never become present, so
+# "Verify publication is complete" would retry until it gave up and the release would
+# never be tagged - an unpublishable version, on every single run.
+missing_from_push=""
+NORM_PUSHED="$(echo "$PUSHED" | norm | sort -u)"
+while read -r pkg; do
+    [[ -z "$pkg" ]] && continue
+    grep -Fqx "$pkg" <<< "$NORM_PUSHED" || missing_from_push="$missing_from_push $pkg"
+done <<< "$STATE_PKGS"
+
+assert "every pack release-state.py waits for is actually pushed" \
+    "$([[ -z "$missing_from_push" ]] && echo 1 || echo 0)"
+[[ -n "$missing_from_push" ]] && echo "        never pushed:$missing_from_push"
+
+missing_from_reservation=""
+while read -r pkg; do
+    [[ -z "$pkg" ]] && continue
+    grep -Fqx "$pkg" <<< "$RESERVED_PKGS" || missing_from_reservation="$missing_from_reservation $pkg"
+done <<< "$STATE_PKGS"
+
+assert "the reservation payload records the same package set" \
+    "$([[ -z "$missing_from_reservation" ]] && echo 1 || echo 0)"
+[[ -n "$missing_from_reservation" ]] && echo "        not reserved:$missing_from_reservation"
+
+# --- durable resume, reservation binding and tag provenance ------------------
+assert "resume is driven by enumerating reservation refs, not by \$OLD" \
+    "$(grep -q "for-each-ref --format='%(refname)' 'refs/tizen-release/v\*'" "$WF" && echo 1 || echo 0)"
+
+assert "a candidate reservation must match this run's inputs before being resumed" \
+    "$(grep -q 'release-reservation.py verify' "$WF" && grep -q -- '--expect-band' "$WF" && echo 1 || echo 0)"
+
+assert "the reservation binds sdk, band, branch, manifest id and package set" \
+    "$(for f in --expect-sdk --expect-band --expect-branch --expect-manifest-id --expect-packages; do
+           grep -q -- "$f" "$WF" || { echo 0; exit; }; done; echo 1)"
+
+assert "the reservation is created as a compare-and-swap that requires absence" \
+    "$(grep -q -- '--force-with-lease="refs/tizen-release/v\$NEW:"' "$WF" && echo 1 || echo 0)"
+
+assert "two unfinished reservations for the same inputs abort rather than guess" \
+    "$(grep -q 'More than one unfinished reservation' "$WF" && echo 1 || echo 0)"
+
+assert "an existing tag is only reused when it targets the reserved commit" \
+    "$(grep -q 'is tagged at \$TAG_SHA but this version was reserved' "$WF" && echo 1 || echo 0)"
+
+assert "a release whose tag cannot be resolved to a commit is rejected" \
+    "$(grep -q 'its tag could not be resolved to a commit' "$WF" && echo 1 || echo 0)"
+
+# --- functional: reservation payload binding ---------------------------------
+#
+# Grep assertions above prove the workflow WIRES the reservation up. These run the real
+# script and prove it actually rejects the mismatches it is supposed to.
+RES="$WORKLOAD_DIR/scripts/release-reservation.py"
+RESDIR="$(mktemp -d)"
+PKGS="Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7,Samsung.NETCore.App.Runtime.tizen,Samsung.Tizen.Sdk,Samsung.Tizen.Templates"
+GOOD_SHA="1111111111111111111111111111111111111111"
+python3 "$RES" encode --version 10.0.128 --sha "$GOOD_SHA" \
+    --sdk 11.0.100-preview.7.26381.103 --band 11.0.100-preview.7 \
+    --manifest-id Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7 \
+    --packages "$PKGS" --branch net10.0 > "$RESDIR/p.json"
+
+assert "a reservation payload round-trips against its own inputs" \
+    "$(python3 "$RES" verify --payload-file "$RESDIR/p.json" --expect-version 10.0.128 \
+        --expect-sdk 11.0.100-preview.7.26381.103 --expect-band 11.0.100-preview.7 \
+        --expect-branch net10.0 --expect-packages "$PKGS" >/dev/null 2>&1 && echo 1 || echo 0)"
+
+assert "the reserved release SHA is recoverable from the payload" \
+    "$([[ "$(python3 "$RES" verify --payload-file "$RESDIR/p.json" --print-field sha)" == "$GOOD_SHA" ]] && echo 1 || echo 0)"
+
+# Each of these is a redispatch that must NOT be allowed to adopt the reservation.
+for bad in "--expect-band 10.0.100" "--expect-sdk 10.0.100" "--expect-branch main" \
+           "--expect-version 10.0.129" "--expect-manifest-id Samsung.NET.Sdk.Tizen.Manifest-10.0.100"; do
+    flag="${bad%% *}"
+    python3 "$RES" verify --payload-file "$RESDIR/p.json" $bad >/dev/null 2>&1
+    assert "a reservation is not adopted when $flag differs" \
+        "$([[ $? -eq 3 ]] && echo 1 || echo 0)"
+done
+
+python3 "$RES" verify --payload-file "$RESDIR/p.json" \
+    --expect-packages "Samsung.Tizen.Sdk,Samsung.Tizen.Templates" >/dev/null 2>&1
+assert "a reservation with a different package set is rejected" \
+    "$([[ $? -eq 3 ]] && echo 1 || echo 0)"
+
+# A bare pre-payload reservation carries no inputs, so it cannot be validated - and
+# therefore must not be resumed rather than being trusted by default.
+echo '{"version":"10.0.128","sha":"'"$GOOD_SHA"'"}' > "$RESDIR/legacy.json"
+python3 "$RES" verify --payload-file "$RESDIR/legacy.json" --expect-version 10.0.128 >/dev/null 2>&1
+assert "a reservation missing its input fields is refused, not trusted" \
+    "$([[ $? -eq 3 ]] && echo 1 || echo 0)"
+
+python3 "$RES" encode --version 10.0.128 --sha "deadbeef" --sdk x --band y \
+    --manifest-id z --packages a --branch b >/dev/null 2>&1
+assert "an abbreviated SHA is refused when reserving" \
+    "$([[ $? -eq 2 ]] && echo 1 || echo 0)"
+rm -rf "$RESDIR"
+
+# --- functional: OLD == NEW must be a no-op, not a failure -------------------
+#
+# The workflow calls `--apply --set-version` OUTSIDE a condition under `set -e`, so a
+# non-zero exit killed the step and made the documented "reserve the current commit"
+# recovery below it unreachable. This proves the exit code, which is what set -e sees.
+NWDIR="$(mktemp -d)"
+cat > "$NWDIR/Versions.props" <<'PROPS'
+<Project>
+  <PropertyGroup>
+    <TizenWorkloadVersion>10.0.128</TizenWorkloadVersion>
+  </PropertyGroup>
+</Project>
+PROPS
+python3 "$WORKLOAD_DIR/scripts/next-workload-version.py" --apply --set-version 10.0.128 \
+    --versions-props "$NWDIR/Versions.props" >/dev/null 2>&1
+assert "--set-version equal to the current value exits 0 (OLD == NEW is resumable)" \
+    "$([[ $? -eq 0 ]] && echo 1 || echo 0)"
+
+assert "the no-op leaves Versions.props byte-identical" \
+    "$(grep -q '<TizenWorkloadVersion>10.0.128</TizenWorkloadVersion>' "$NWDIR/Versions.props" && echo 1 || echo 0)"
+
+# Going BACKWARDS is still a hard error: only the equal case is a resume.
+python3 "$WORKLOAD_DIR/scripts/next-workload-version.py" --apply --set-version 10.0.127 \
+    --versions-props "$NWDIR/Versions.props" >/dev/null 2>&1
+assert "--set-version below the current value is still refused" \
+    "$([[ $? -ne 0 ]] && echo 1 || echo 0)"
+rm -rf "$NWDIR"
+
+# --- functional: a 200 that cannot be parsed is not "never published" --------
+FEED="$(mktemp -d)"
+mkdir -p "$FEED/samsung.tizen.sdk"
+# `{}` used to yield [] via .get("versions", []), making a published package look missing.
+echo '{}' > "$FEED/samsung.tizen.sdk/index.json"
+python3 "$WORKLOAD_DIR/scripts/release-state.py" --version 10.0.128 \
+    --band 11.0.100-preview.7 --feed-base "file://$FEED" >/dev/null 2>&1
+assert "an index with no 'versions' key is an error, not absence" \
+    "$([[ $? -eq 2 ]] && echo 1 || echo 0)"
+
+echo '{"versions": "10.0.128"}' > "$FEED/samsung.tizen.sdk/index.json"
+python3 "$WORKLOAD_DIR/scripts/release-state.py" --version 10.0.128 \
+    --band 11.0.100-preview.7 --feed-base "file://$FEED" >/dev/null 2>&1
+assert "an index whose 'versions' is not a list is an error" \
+    "$([[ $? -eq 2 ]] && echo 1 || echo 0)"
+rm -rf "$FEED"
+
+# --- functional: the search index is paginated and validated -----------------
+#
+# The search endpoint caps results per request, so a single query returned only the first
+# page. The stub feed puts the highest build counter on the LAST page: an unpaginated
+# reader answers 10.0.102 (a version already published) instead of 10.0.106.
+STUB="$WORKLOAD_DIR/scripts/stub-nuget-search.py"
+assert "the search index is paginated to completion" \
+    "$([[ "$(python3 "$STUB" ok)" == "rc=0 out=10.0.106" ]] && echo 1 || echo 0)"
+
+for mode in truncated nototal badtotal; do
+    assert "a $mode search response aborts instead of lowering the version" \
+        "$([[ "$(python3 "$STUB" "$mode")" == "rc=1 out=" ]] && echo 1 || echo 0)"
+done
+
+
+# --- failure injection against the real state script # --- failure injection against the real state script -------------------------
 #
 # Simulates a release interrupted at each step, using a local file:// feed, and asserts the
 # resume decision the workflow would make.

--- a/workload/scripts/test-release-workflow.sh
+++ b/workload/scripts/test-release-workflow.sh
@@ -64,7 +64,8 @@ line_of() {
 
 BUILD_LN=$(line_of "    - name: Build")
 STAGE_LN=$(line_of "    - name: Stage and verify packages")
-COMMIT_LN=$(line_of "    - name: Commit and push the version bump")
+RESERVE_LN=$(line_of "    - name: Resolve and reserve release version")
+CHECKOUT_LN=$(line_of "    - name: Check out the reserved release commit")
 PUSH_LN=$(line_of "    - name: Push SDK/Runtime/Templates packs")
 REL_LN=$(line_of "    - name: Create GitHub Release")
 
@@ -73,33 +74,59 @@ REL_LN=$(line_of "    - name: Create GitHub Release")
 assert "build runs before staging" \
     "$([[ -n "$BUILD_LN" && -n "$STAGE_LN" && "$BUILD_LN" -lt "$STAGE_LN" ]] && echo 1 || echo 0)"
 
-assert "version bump is persisted AFTER staging verification" \
-    "$([[ -n "$STAGE_LN" && -n "$COMMIT_LN" && "$STAGE_LN" -lt "$COMMIT_LN" ]] && echo 1 || echo 0)"
+# The release commit is now created FIRST so every package embeds the same SHA as the tag.
+# Retryability comes from the reservation ref + resume detection, not from deferring it.
+assert "version is reserved before the build" \
+    "$([[ -n "$RESERVE_LN" && -n "$BUILD_LN" && "$RESERVE_LN" -lt "$BUILD_LN" ]] && echo 1 || echo 0)"
 
-assert "version bump is persisted BEFORE packages are pushed" \
-    "$([[ -n "$COMMIT_LN" && -n "$PUSH_LN" && "$COMMIT_LN" -lt "$PUSH_LN" ]] && echo 1 || echo 0)"
+assert "reserved commit is checked out before the build" \
+    "$([[ -n "$CHECKOUT_LN" && -n "$BUILD_LN" && "$CHECKOUT_LN" -lt "$BUILD_LN" ]] && echo 1 || echo 0)"
+
+assert "ownership is claimed via an atomic reservation ref" \
+    "$(grep -q 'refs/tizen-release/v' "$WF" && echo 1 || echo 0)"
+
+assert "a foreign reservation aborts the run" \
+    "$(grep -q 'already reserved by another release' "$WF" && echo 1 || echo 0)"
+
+assert "releases are serialized by a concurrency group" \
+    "$(grep -q 'group: tizen-workload-release' "$WF" && echo 1 || echo 0)"
+
+assert "in-flight releases are never cancelled" \
+    "$(grep -q 'cancel-in-progress: false' "$WF" && echo 1 || echo 0)"
+
+assert "the build runs from the reserved SHA, not the event SHA" \
+    "$(grep -q 'git checkout --detach "\$SHA"' "$WF" && echo 1 || echo 0)"
+
+assert "source drift against the reserved version is rejected" \
+    "$(grep -q 'Source drift' "$WF" && echo 1 || echo 0)"
+
+assert "the applied version is pinned explicitly (--set-version)" \
+    "$(grep -q 'next-workload-version.py --apply --set-version' "$WF" && echo 1 || echo 0)"
+
+assert "every package is verified to carry the reserved commit" \
+    "$(grep -q 'do not all originate from the reserved release commit' "$WF" && echo 1 || echo 0)"
 
 assert "release tag is created last" \
     "$([[ -n "$PUSH_LN" && -n "$REL_LN" && "$PUSH_LN" -lt "$REL_LN" ]] && echo 1 || echo 0)"
 
 # --- retryability / non-mutation --------------------------------------------
 
-assert "OLD == NEW resumes instead of aborting" \
-    "$(grep -q 'Resuming release of' "$WF" && ! grep -q 'ERROR: computed next == current' "$WF" && echo 1 || echo 0)"
+assert "OLD == NEW reserves the current commit instead of failing" \
+    "$(grep -q 'is already \$NEW; reserving the current commit' "$WF" && ! grep -q 'ERROR: computed next == current' "$WF" && echo 1 || echo 0)"
 
 assert "reference-only run is non-mutating" \
     "$(grep -q 'Reference-only run: leaving TizenWorkloadVersion' "$WF" && echo 1 || echo 0)"
 
-assert "commit step is skipped when nothing was mutated" \
-    "$(grep -q 'steps.bump.outputs.mutated' "$WF" && echo 1 || echo 0)"
+assert "a resumed run rebuilds from the reservation's commit" \
+    "$(grep -q 'no reservation ref exists' "$WF" && echo 1 || echo 0)"
 
 assert "build is not continue-on-error" \
     "$(awk -v s="$BUILD_LN" -v e="$STAGE_LN" 'NR>s && NR<e && /continue-on-error/ {found=1} END{exit !found}' "$WF" && echo 0 || echo 1)"
 
 # --- correctness of what gets published -------------------------------------
 
-assert "tag targets the released commit, not just the branch ref" \
-    "$(grep -q 'steps.commit.outputs.release_sha' "$WF" && echo 1 || echo 0)"
+assert "tag targets the reserved release commit" \
+    "$(grep -q 'target "\${{ steps.bump.outputs.release_sha }}"' "$WF" && echo 1 || echo 0)"
 
 assert "release notes use the staged manifest id" \
     "$(grep -q 'steps.stage.outputs.manifest_id' "$WF" && echo 1 || echo 0)"
@@ -129,7 +156,7 @@ assert "a partially published version is resumed, never advanced" \
     "$(grep -q 'is partially published' "$WF" && echo 1 || echo 0)"
 
 assert "a published-but-untagged version is resumed to finish the tag" \
-    "$(grep -q 'fully published but has no release tag' "$WF" && echo 1 || echo 0)"
+    "$(grep -q 'is published but untagged' "$WF" && echo 1 || echo 0)"
 
 assert "companion packs are pushed BEFORE the manifest" \
     "$([[ -n "$COMPANION_PUSH_LN" && -n "$MANIFEST_PUSH_LN" && "$COMPANION_PUSH_LN" -lt "$MANIFEST_PUSH_LN" ]] && echo 1 || echo 0)"

--- a/workload/scripts/test-release-workflow.sh
+++ b/workload/scripts/test-release-workflow.sh
@@ -48,12 +48,24 @@ assert() {
     fi
 }
 
-line_of() { grep -n -- "$1" "$WF" | head -1 | cut -d: -f1; }
+# Resolve a step's line number. A missing anchor is a hard error: silently returning an
+# empty value would turn every ordering assertion that uses it into a confusing failure.
+line_of() {
+    local ln
+    ln="$(grep -n -F -- "$1" "$WF" | head -1 | cut -d: -f1)"
+    if [[ -z "$ln" ]]; then
+        printf "  %sFAIL%s  workflow step not found: %s\n" "$c_red" "$c_reset" "$1"
+        fail=$((fail + 1))
+        echo 0
+        return
+    fi
+    echo "$ln"
+}
 
 BUILD_LN=$(line_of "    - name: Build")
 STAGE_LN=$(line_of "    - name: Stage and verify packages")
 COMMIT_LN=$(line_of "    - name: Commit and push the version bump")
-PUSH_LN=$(line_of "    - name: Push Manifest/SDK/Runtime packs")
+PUSH_LN=$(line_of "    - name: Push SDK/Runtime/Templates packs")
 REL_LN=$(line_of "    - name: Create GitHub Release")
 
 # --- ordering ---------------------------------------------------------------
@@ -103,6 +115,81 @@ assert "no push globs the raw workspace output directory" \
 
 assert "existing release tag is a no-op (resumable)" \
     "$(grep -q 'already exists; skipping creation' "$WF" && echo 1 || echo 0)"
+
+# --- partial-publication resume ---------------------------------------------
+
+MANIFEST_PUSH_LN=$(line_of "    - name: Push Manifest pack")
+COMPANION_PUSH_LN=$(line_of "    - name: Push SDK/Runtime/Templates packs")
+VERIFY_LN=$(line_of "    - name: Verify publication is complete")
+
+assert "publication state is inspected before advancing the version" \
+    "$(grep -q 'release-state.py --version "\$OLD"' "$WF" && echo 1 || echo 0)"
+
+assert "a partially published version is resumed, never advanced" \
+    "$(grep -q 'is partially published' "$WF" && echo 1 || echo 0)"
+
+assert "a published-but-untagged version is resumed to finish the tag" \
+    "$(grep -q 'fully published but has no release tag' "$WF" && echo 1 || echo 0)"
+
+assert "companion packs are pushed BEFORE the manifest" \
+    "$([[ -n "$COMPANION_PUSH_LN" && -n "$MANIFEST_PUSH_LN" && "$COMPANION_PUSH_LN" -lt "$MANIFEST_PUSH_LN" ]] && echo 1 || echo 0)"
+
+assert "publication completeness is verified before tagging" \
+    "$([[ -n "$VERIFY_LN" && -n "$REL_LN" && "$VERIFY_LN" -lt "$REL_LN" ]] && echo 1 || echo 0)"
+
+assert "every push is idempotent (--skip-duplicate)" \
+    "$([[ "$(grep -c 'skip-duplicate' "$WF")" -ge 3 ]] && echo 1 || echo 0)"
+
+# --- failure injection against the real state script -------------------------
+#
+# Simulates a release interrupted at each step, using a local file:// feed, and asserts the
+# resume decision the workflow would make.
+
+STATE_PY="$WORKLOAD_DIR/scripts/release-state.py"
+FEED="$(mktemp -d)"
+trap 'rm -rf "$FEED"' EXIT
+
+seed() {  # seed <package-id> <version>
+    mkdir -p "$FEED/$1"
+    printf '{"versions":["%s"]}' "$2" > "$FEED/$1/index.json"
+}
+state_of() {
+    python3 "$STATE_PY" --version "$1" --band 11.0.100-preview.7 \
+        --feed-base "file://$FEED" 2>/dev/null | sed -n 's/^state=//p'
+}
+
+V=10.0.130
+MANIFEST_ID=samsung.net.sdk.tizen.manifest-11.0.100-preview.7
+
+echo ""
+echo "-- failure injection --"
+
+rm -rf "$FEED"; mkdir -p "$FEED"
+assert "nothing published -> unpublished" "$([[ "$(state_of $V)" == "unpublished" ]] && echo 1 || echo 0)"
+
+# Interrupted immediately after the manifest push (the exact case that stranded V).
+seed "$MANIFEST_ID" "$V"
+assert "interrupted after manifest push -> partial" "$([[ "$(state_of $V)" == "partial" ]] && echo 1 || echo 0)"
+
+# Interrupted midway through the companion packs.
+seed samsung.tizen.sdk "$V"
+assert "interrupted after one companion pack -> partial" "$([[ "$(state_of $V)" == "partial" ]] && echo 1 || echo 0)"
+
+seed samsung.netcore.app.runtime.tizen "$V"
+assert "interrupted before the last pack -> partial" "$([[ "$(state_of $V)" == "partial" ]] && echo 1 || echo 0)"
+
+seed samsung.tizen.templates "$V"
+assert "all packs present -> published" "$([[ "$(state_of $V)" == "published" ]] && echo 1 || echo 0)"
+
+# A different version must be unaffected by V's artifacts.
+assert "an unrelated version is still unpublished" "$([[ "$(state_of 10.0.131)" == "unpublished" ]] && echo 1 || echo 0)"
+
+# A feed that cannot be reached must NOT read as "unpublished" - that would advance the
+# version and strand the partial release.
+python3 "$STATE_PY" --version "$V" --band 11.0.100-preview.7 \
+    --feed-base "http://127.0.0.1:9/unreachable" >/dev/null 2>&1
+assert "unreachable feed exits non-zero (never 'unpublished')" \
+    "$([[ $? -ne 0 ]] && echo 1 || echo 0)"
 
 echo ""
 echo "=========== release-workflow summary ==========="

--- a/workload/scripts/test-template-conditions.sh
+++ b/workload/scripts/test-template-conditions.sh
@@ -3,19 +3,32 @@
 # Copyright (c) Samsung Electronics. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
-# Evaluation regression test for the Tizen template's platform-version detection.
+# Evaluation regression tests for Tizen MSBuild conditions. Two independent suites run here,
+# both against real shipped files (extracted, never duplicated, so they cannot drift), and
+# both without the Tizen workload — so they run in the metadata CI job.
 #
-# The template conditions its Tizen.UI.Components.Material PackageReference on the Tizen
-# platform band. PackageReference items are evaluated with the project body, which runs
-# BEFORE the .NET SDK infers $(TargetPlatformVersion) from the TFM — so the detection must
-# parse $(TargetFramework) itself. Reading $(TargetPlatformVersion) in the body silently
-# yields an empty string and falls back to the default, which wrongly pulls Material into
-# e.g. net11.0-tizen9.0 and suppresses TIZENTMPL001.
+# Suite 1 — template platform-version detection:
+#   The template conditions its Tizen.UI.Components.Material PackageReference on the Tizen
+#   platform band. PackageReference items are evaluated with the project body, which runs
+#   BEFORE the .NET SDK infers $(TargetPlatformVersion) from the TFM — so the detection must
+#   parse $(TargetFramework) itself. Reading $(TargetPlatformVersion) in the body silently
+#   yields an empty string and falls back to the default, which wrongly pulls Material into
+#   e.g. net11.0-tizen9.0 and suppresses TIZENTMPL001. Extracted from the shipped template
+#   csproj between the BEGIN/END TIZEN UI PLATFORM DETECTION markers.
 #
-# This test extracts the real PropertyGroup from the shipped template csproj (between the
-# BEGIN/END TIZEN UI PLATFORM DETECTION markers) and evaluates it against a table of TFMs.
-# Extracting rather than duplicating means the test cannot drift from what ships, and it
-# needs no Tizen workload — so it runs in the metadata CI job.
+# Suite 2 — the _TizenErrorOnSelfContained (TIZENSDK001) self-contained guard:
+#   Samsung.NETCore.App.Runtime.tizen is a placeholder runtime pack with no runtime binaries,
+#   so a self-contained Tizen publish cannot work and the guard errors with TIZENSDK001. The
+#   guard must fire ONLY when self-contained was *explicitly* requested. The trap: the .NET SDK
+#   still infers SelfContained=true from a present RuntimeIdentifier on pre-8.0 TFMs
+#   (Microsoft.NET.RuntimeIdentifierInference.targets), and the Tizen SDK supplies an implicit
+#   RID for MAUI apps — so an ordinary framework-dependent net6.0-tizen / net7.0-tizen build
+#   has SelfContained inferred to 'true'. Gating on the SDK's own _SelfContainedWasSpecified
+#   (set only for an explicit request) instead of the inferred $(SelfContained) is what keeps
+#   those builds working. This suite extracts the real guard <Target> from the shipped
+#   Samsung.Tizen.Sdk.targets, embeds it in an SDK-style probe (so the SDK parses the -tizen TFM
+#   to TargetPlatformIdentifier=tizen and runs the identical RID/SelfContained inference), and
+#   invokes the guard target directly to assert TIZENSDK001 fires exactly when it should.
 #
 # Usage:
 #   bash workload/scripts/test-template-conditions.sh
@@ -29,6 +42,7 @@ set -uo pipefail
 
 WORKLOAD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 CSPROJ="$WORKLOAD_DIR/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj"
+SDK_TARGETS="$WORKLOAD_DIR/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets"
 DOTNET="${DOTNET:-dotnet}"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -104,6 +118,85 @@ for case in "${CASES[@]}"; do
     else
         printf "  %sFAIL%s  %-22s -> platform=%-5s material=%-5s (expected %s / %s)\n" \
             "$c_red" "$c_reset" "$label" "${got_ver:-?}" "${got_mat:-?}" "$want_ver" "$want_mat"
+        fail=$((fail + 1))
+    fi
+done
+
+# --------------------------------------------------------------------------------------------
+# Suite 2 — self-contained guard (_TizenErrorOnSelfContained / TIZENSDK001).
+#
+# Extract the real guard <Target> from the shipped SDK targets (never duplicate it, so the test
+# tracks whatever ships) and embed it in an SDK-style probe. Because the probe uses
+# Sdk="Microsoft.NET.Sdk" and a -tizen TFM, the .NET SDK parses TargetPlatformIdentifier=tizen
+# and runs the exact same RuntimeIdentifier -> SelfContained inference as a production build,
+# with no Tizen workload required. Invoking the guard target directly evaluates its Condition
+# against those SDK-inferred property values and emits TIZENSDK001 iff the guard would fire.
+# --------------------------------------------------------------------------------------------
+
+if [[ ! -f "$SDK_TARGETS" ]]; then
+    echo "ERROR: SDK targets not found at $SDK_TARGETS"
+    exit 2
+fi
+
+GUARD="$(sed -n '/<Target Name="_TizenErrorOnSelfContained"/,/<\/Target>/p' "$SDK_TARGETS")"
+
+if [[ -z "$GUARD" ]]; then
+    echo "ERROR: _TizenErrorOnSelfContained target not found in $SDK_TARGETS."
+    echo "       Keep the target intact so this self-contained regression test stays honest."
+    exit 2
+fi
+
+# EnableDefaultCompileItems=false keeps the probe from needing any source; OutputType=Exe makes
+# HasRuntimeOutput true, which is the gate the SDK requires before it will infer SelfContained.
+{
+    echo '<Project Sdk="Microsoft.NET.Sdk">'
+    echo '  <PropertyGroup>'
+    echo '    <OutputType>Exe</OutputType>'
+    echo '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>'
+    echo '  </PropertyGroup>'
+    echo "$GUARD"
+    echo '</Project>'
+} > "$TMPDIR/guard.csproj"
+
+# Cases: "<label>|<expected: error|ok>|<extra -p args>"
+#
+# An implicit RID (tizen-x86, as the Tizen SDK sets for MAUI) is passed on the framework-
+# dependent rows precisely to reproduce the SDK's SelfContained inference. net6.0/net7.0 infer
+# SelfContained=true from that RID; the guard must still stay silent because self-contained was
+# not explicitly requested (_SelfContainedWasSpecified is empty). An explicit request must error;
+# the skip property must bypass; and PublishSelfContained during publish must still error (the
+# SDK copies it onto SelfContained before computing _SelfContainedWasSpecified).
+GUARD_CASES=(
+    # Framework-dependent builds with the implicit RID present: must NOT error.
+    "net6.0-tizen fwdep|ok|-p:TargetFramework=net6.0-tizen -p:RuntimeIdentifier=tizen-x86"
+    "net7.0-tizen fwdep|ok|-p:TargetFramework=net7.0-tizen -p:RuntimeIdentifier=tizen-x86"
+    "net8.0-tizen fwdep|ok|-p:TargetFramework=net8.0-tizen -p:RuntimeIdentifier=tizen-x86"
+    "net11.0-tizen11.0 fwdep|ok|-p:TargetFramework=net11.0-tizen11.0 -p:RuntimeIdentifier=tizen-x86"
+    # Explicitly requested self-contained: MUST error with TIZENSDK001.
+    "net6.0-tizen SelfContained=true|error|-p:TargetFramework=net6.0-tizen -p:RuntimeIdentifier=tizen-x86 -p:SelfContained=true"
+    "net11.0-tizen11.0 SelfContained=true|error|-p:TargetFramework=net11.0-tizen11.0 -p:RuntimeIdentifier=tizen-x86 -p:SelfContained=true"
+    "net6.0-tizen publish --self-contained|error|-p:TargetFramework=net6.0-tizen -p:RuntimeIdentifier=tizen-x86 -p:PublishSelfContained=true -p:_IsPublishing=true"
+    # Explicit self-contained but bypassed via the skip property: must NOT error.
+    "net6.0-tizen SelfContained=true + Skip|ok|-p:TargetFramework=net6.0-tizen -p:RuntimeIdentifier=tizen-x86 -p:SelfContained=true -p:SkipTizenSelfContainedCheck=true"
+    # Explicit SelfContained=false must never error even where a RID is present.
+    "net6.0-tizen SelfContained=false|ok|-p:TargetFramework=net6.0-tizen -p:RuntimeIdentifier=tizen-x86 -p:SelfContained=false"
+)
+
+for case in "${GUARD_CASES[@]}"; do
+    IFS='|' read -r label want args <<< "$case"
+
+    # -nodereuse:false: MSBuild node reuse caches loaded task assemblies and project state across
+    # invocations and has previously caused tests in this repo to silently validate stale state.
+    out="$("$DOTNET" msbuild "$TMPDIR/guard.csproj" -t:_TizenErrorOnSelfContained \
+            -nologo -v:m -nodereuse:false $args 2>&1)"
+    if echo "$out" | grep -q 'TIZENSDK001'; then got="error"; else got="ok"; fi
+
+    if [[ "$got" == "$want" ]]; then
+        printf "  %sPASS%s  %-38s -> %s\n" "$c_green" "$c_reset" "$label" "$got"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-38s -> %s (expected %s)\n" "$c_red" "$c_reset" "$label" "$got" "$want"
+        echo "$out" | grep -iE 'error|TIZENSDK' | head -3 | sed 's/^/        | /'
         fail=$((fail + 1))
     fi
 done

--- a/workload/scripts/test-template-conditions.sh
+++ b/workload/scripts/test-template-conditions.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+# Evaluation regression test for the Tizen template's platform-version detection.
+#
+# The template conditions its Tizen.UI.Components.Material PackageReference on the Tizen
+# platform band. PackageReference items are evaluated with the project body, which runs
+# BEFORE the .NET SDK infers $(TargetPlatformVersion) from the TFM — so the detection must
+# parse $(TargetFramework) itself. Reading $(TargetPlatformVersion) in the body silently
+# yields an empty string and falls back to the default, which wrongly pulls Material into
+# e.g. net11.0-tizen9.0 and suppresses TIZENTMPL001.
+#
+# This test extracts the real PropertyGroup from the shipped template csproj (between the
+# BEGIN/END TIZEN UI PLATFORM DETECTION markers) and evaluates it against a table of TFMs.
+# Extracting rather than duplicating means the test cannot drift from what ships, and it
+# needs no Tizen workload — so it runs in the metadata CI job.
+#
+# Usage:
+#   bash workload/scripts/test-template-conditions.sh
+#   make -C workload test-template-conditions
+#
+# Environment overrides:
+#   DOTNET   path to the dotnet command (default: dotnet from PATH)
+#
+
+set -uo pipefail
+
+WORKLOAD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CSPROJ="$WORKLOAD_DIR/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj"
+DOTNET="${DOTNET:-dotnet}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+c_reset=$'\033[0m'; c_red=$'\033[31m'; c_green=$'\033[32m'; c_yellow=$'\033[33m'
+[[ -t 1 ]] || { c_reset=""; c_red=""; c_green=""; c_yellow=""; }
+
+if ! command -v "$DOTNET" >/dev/null 2>&1; then
+    echo "  ${c_yellow}SKIP${c_reset}  '$DOTNET' not found; cannot evaluate MSBuild expressions."
+    exit 0
+fi
+
+if [[ ! -f "$CSPROJ" ]]; then
+    echo "ERROR: template csproj not found at $CSPROJ"
+    exit 2
+fi
+
+DETECTION="$(sed -n '/BEGIN TIZEN UI PLATFORM DETECTION/,/END TIZEN UI PLATFORM DETECTION/p' "$CSPROJ" \
+             | sed -n '/<PropertyGroup>/,/<\/PropertyGroup>/p')"
+
+if [[ -z "$DETECTION" ]]; then
+    echo "ERROR: TIZEN UI PLATFORM DETECTION markers (or the PropertyGroup between them)"
+    echo "       not found in $CSPROJ. Keep the markers intact so this test stays honest."
+    exit 2
+fi
+
+# Build a probe project containing the extracted PropertyGroup verbatim.
+{
+    echo '<Project>'
+    echo "$DETECTION"
+    echo '  <Target Name="Probe">'
+    echo '    <Message Importance="high" Text="RESULT|$(_TizenUIPlatformVersion)|$(_TizenUIMaterialSupported)" />'
+    echo '  </Target>'
+    echo '</Project>'
+} > "$TMPDIR/probe.proj"
+
+# Cases: "<TargetFramework>|<expected platform version>|<expected material supported>"
+CASES=(
+    # Below the Material floor: must NOT reference Material.
+    "net11.0-tizen8.0|8.0|False"
+    "net11.0-tizen9.0|9.0|False"
+    "net10.0-tizen8.0|8.0|False"
+    "net8.0-tizen9.0|9.0|False"
+    # At or above the floor: Material is referenced.
+    "net11.0-tizen10.0|10.0|True"
+    "net11.0-tizen10.1|10.1|True"
+    "net11.0-tizen11.0|11.0|True"
+    "net10.0-tizen10.0|10.0|True"
+    "net8.0-tizen11.0|11.0|True"
+    # Unversioned / outer multi-targeting build: assume the SDK default (10.0).
+    "net11.0-tizen|10.0|True"
+    "net10.0-tizen|10.0|True"
+    "|10.0|True"
+    # A non-Tizen TFM must not be misparsed.
+    "net10.0|10.0|True"
+)
+
+pass=0; fail=0
+
+for case in "${CASES[@]}"; do
+    IFS='|' read -r tfm want_ver want_mat <<< "$case"
+
+    out="$("$DOTNET" msbuild "$TMPDIR/probe.proj" -t:Probe -nologo -v:m \
+            -p:TargetFramework="$tfm" 2>&1 | grep -o 'RESULT|[^|]*|[^ ]*' | head -1)"
+    got_ver="$(echo "$out" | cut -d'|' -f2)"
+    got_mat="$(echo "$out" | cut -d'|' -f3)"
+
+    label="${tfm:-<empty>}"
+    if [[ "$got_ver" == "$want_ver" && "$got_mat" == "$want_mat" ]]; then
+        printf "  %sPASS%s  %-22s -> platform=%-5s material=%s\n" \
+            "$c_green" "$c_reset" "$label" "$got_ver" "$got_mat"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-22s -> platform=%-5s material=%-5s (expected %s / %s)\n" \
+            "$c_red" "$c_reset" "$label" "${got_ver:-?}" "${got_mat:-?}" "$want_ver" "$want_mat"
+        fail=$((fail + 1))
+    fi
+done
+
+echo ""
+echo "============ template-conditions summary ============"
+echo "  passed: $pass"
+echo "  failed: $fail"
+
+[[ $fail -eq 0 ]] || exit 1
+exit 0

--- a/workload/scripts/test-version-band.sh
+++ b/workload/scripts/test-version-band.sh
@@ -24,6 +24,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKLOAD_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SH_SCRIPT="$SCRIPT_DIR/workload-install.sh"
 PS1_SCRIPT="$SCRIPT_DIR/workload-install.ps1"
 
@@ -87,45 +88,137 @@ for case in "${CASES[@]}"; do
     fi
 done
 
-# --- parity check: the PowerShell installer must agree ---------------------
+# --- parity check: load the REAL PowerShell implementation -----------------
 #
-# workload-install.ps1 reimplements the same logic. Run the same cases through
-# pwsh when it is available so the two installers cannot drift apart.
+# The PS logic is extracted from workload-install.ps1 between the same
+# BEGIN/END VERSION BAND DETECTION markers and dot-sourced, rather than
+# reimplemented here. A hand-copied reimplementation would agree with itself
+# forever and could never detect the two installers drifting apart.
 
 if command -v pwsh >/dev/null 2>&1 && [[ -f "$PS1_SCRIPT" ]]; then
     echo ""
-    echo "-- PowerShell parity --"
+    echo "-- PowerShell parity (real Get-TargetVersionBand) --"
+
+    ps_results="$(pwsh -NoProfile -Command "
+        \$src = Get-Content -Raw '$PS1_SCRIPT'
+        \$block = [regex]::Match(\$src, '(?s)# BEGIN VERSION BAND DETECTION.*?# END VERSION BAND DETECTION').Value
+        if (-not \$block) { Write-Output 'EXTRACT_FAILED'; exit 1 }
+        Invoke-Expression \$block
+        foreach (\$v in @($(printf "'%s'," "${CASES[@]%%|*}" | sed 's/,$//'))) {
+            Write-Output (\$v + '=' + (Get-TargetVersionBand -DotnetVersion \$v))
+        }" 2>/dev/null | tr -d '\r')"
+
+    if [[ "$ps_results" == *EXTRACT_FAILED* || -z "$ps_results" ]]; then
+        printf "  %sFAIL%s  could not extract Get-TargetVersionBand from workload-install.ps1\n" "$c_red" "$c_reset"
+        fail=$((fail + 1))
+    else
+        for case in "${CASES[@]}"; do
+            version="${case%%|*}"
+            expected="${case##*|}"
+            actual="$(grep -F "$version=" <<< "$ps_results" | head -1 | cut -d'=' -f2-)"
+            if [[ "$actual" == "$expected" ]]; then
+                printf "  %sPASS%s  %-32s -> %s\n" "$c_green" "$c_reset" "$version" "$actual"
+                pass=$((pass + 1))
+            else
+                printf "  %sFAIL%s  %-32s -> %s (expected %s)\n" "$c_red" "$c_reset" "$version" "${actual:-<none>}" "$expected"
+                fail=$((fail + 1))
+            fi
+        done
+    fi
+else
+    echo ""
+    echo "  (pwsh not available - skipping workload-install.ps1 parity check)"
+fi
+
+# --- fallback family: an 11.x request must never resolve to a 10.x manifest ----
+#
+# The PowerShell fallback used a fixed-length prefix, so '...Manifest-11.0.100-preview.7'
+# was truncated to '...Manifest-1' and matched the 10.x entries, installing a .NET 10
+# manifest into an 11.x band. Both installers must now stay inside one major.minor family.
+
+echo ""
+echo "-- fallback band family --"
+
+FALLBACK_CASES=(
+    "samsung.net.sdk.tizen.manifest-11.0.100-preview.7|samsung.net.sdk.tizen.manifest-11.0."
+    "samsung.net.sdk.tizen.manifest-10.0.300|samsung.net.sdk.tizen.manifest-10.0."
+    "samsung.net.sdk.tizen.manifest-9.0.100-rc.1|samsung.net.sdk.tizen.manifest-9.0."
+    "samsung.net.sdk.tizen.manifest-6.0.400|samsung.net.sdk.tizen.manifest-6.0."
+)
+
+for case in "${FALLBACK_CASES[@]}"; do
+    mid="${case%%|*}"
+    want="${case##*|}"
+    family="${mid#*-}"
+    family="$(echo "$family" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')"
+    got="${mid%%-*}-${family}."
+    if [[ "$got" == "$want" ]]; then
+        printf "  %sPASS%s  %-48s -> %s\n" "$c_green" "$c_reset" "$mid" "$got"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-48s -> %s (expected %s)\n" "$c_red" "$c_reset" "$mid" "$got" "$want"
+        fail=$((fail + 1))
+    fi
+done
+
+# The 11.x family prefix must not match any 10.x map key.
+if grep -q 'MANIFEST_BASE_NAME-10\.' "$SH_SCRIPT" && \
+   ! grep -q '"\$MANIFEST_BASE_NAME-11\.0\.' "$SH_SCRIPT"; then
+    printf "  %sPASS%s  %-48s\n" "$c_green" "$c_reset" "11.0 family has no map entry (fallback must fail closed)"
+    pass=$((pass + 1))
+fi
+
+# --- producer/consumer parity: Config.mk must agree with the installers -------
+#
+# Config.mk decides where `make install` puts the manifest; the installers decide where
+# the SDK looks for it. If they disagree the workload installs into a directory nothing
+# reads. Config.mk previously did NOT round the feature band for stable non-6 versions,
+# so 10.0.404 produced band '10.0.404' while the installers looked for '10.0.400'.
+
+echo ""
+echo "-- Config.mk producer parity --"
+
+if command -v make >/dev/null 2>&1; then
     for case in "${CASES[@]}"; do
         version="${case%%|*}"
         expected="${case##*|}"
-        actual="$(pwsh -NoProfile -Command "
-            \$DotnetVersion = '$version'
-            \$VersionSplitSymbol = '.'
-            \$SplitVersion = \$DotnetVersion.Split(\$VersionSplitSymbol)
-            \$CurrentDotnetVersion = [Version]\"\$(\$SplitVersion[0]).\$(\$SplitVersion[1])\"
-            \$DotnetVersionBand = \$SplitVersion[0] + \$VersionSplitSymbol + \$SplitVersion[1] + \$VersionSplitSymbol + \$SplitVersion[2][0] + '00'
-            \$DotnetTargetVersionBand = \$DotnetVersionBand
-            if (\$CurrentDotnetVersion -ge [Version]'7.0') {
-                \$IsPreviewVersion = \$DotnetVersion.Contains('-preview') -or \$DotnetVersion.Contains('-rc') -or \$DotnetVersion.Contains('-alpha')
-                if (\$IsPreviewVersion -and (\$SplitVersion.Count -ge 4)) {
-                    \$DotnetTargetVersionBand = \$DotnetVersionBand + \$SplitVersion[2].SubString(3) + \$VersionSplitSymbol + \$(\$SplitVersion[3])
-                }
-                elseif (\$DotnetVersion.Contains('-rtm') -and (\$SplitVersion.Count -ge 3)) {
-                    \$DotnetTargetVersionBand = \$DotnetVersionBand + \$SplitVersion[2].SubString(3)
-                }
-            }
-            Write-Output \$DotnetTargetVersionBand" 2>/dev/null | tr -d '\r')"
+        # Config.mk only handles versions it can split; skip the ones make can't model.
+        actual="$(make -s -C "$WORKLOAD_DIR" print-version-band DOTNET_VERSION="$version" 2>/dev/null | tail -1)"
         if [[ "$actual" == "$expected" ]]; then
             printf "  %sPASS%s  %-32s -> %s\n" "$c_green" "$c_reset" "$version" "$actual"
             pass=$((pass + 1))
         else
-            printf "  %sFAIL%s  %-32s -> %s (expected %s)\n" "$c_red" "$c_reset" "$version" "$actual" "$expected"
+            printf "  %sFAIL%s  %-32s -> %s (installers say %s)\n" "$c_red" "$c_reset" "$version" "${actual:-<none>}" "$expected"
             fail=$((fail + 1))
         fi
     done
 else
-    echo ""
-    echo "  (pwsh not available - skipping workload-install.ps1 parity check)"
+    echo "  (make not available - skipping Config.mk parity check)"
+fi
+
+# --- band isolation: one tree must not reuse another band's SDK ---------------
+#
+# DOTNET_DESTDIR and the install stamp were previously unscoped, so
+# `make install DOTNET_VERSION=11...` in a tree that had already built .NET 10 reused the
+# old SDK and silently tested the wrong band.
+
+echo ""
+echo "-- band isolation --"
+
+if command -v make >/dev/null 2>&1; then
+    for var in print-dotnet-destdir print-install-stamp; do
+        a="$(DOTNET_VERSION=10.0.100 make -s -C "$WORKLOAD_DIR" $var 2>/dev/null | tail -1)"
+        b="$(DOTNET_VERSION=11.0.100-preview.7.26381.103 make -s -C "$WORKLOAD_DIR" $var 2>/dev/null | tail -1)"
+        if [[ -n "$a" && -n "$b" && "$a" != "$b" ]]; then
+            printf "  %sPASS%s  %-24s differs across bands\n" "$c_green" "$c_reset" "$var"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  %-24s same for both bands (%s)\n" "$c_red" "$c_reset" "$var" "$a"
+            fail=$((fail + 1))
+        fi
+    done
+else
+    echo "  (make not available - skipping band isolation check)"
 fi
 
 echo ""

--- a/workload/scripts/test-version-band.sh
+++ b/workload/scripts/test-version-band.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Copyright (c) Samsung Electronics. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+# Unit test for the SDK feature-band detection used by the install scripts.
+#
+# The band string decides three things at install time:
+#   * the NuGet package id     Samsung.NET.Sdk.Tizen.Manifest-<band>
+#   * the manifest directory   <dotnet>/sdk-manifests/<band>/samsung.net.sdk.tizen
+#   * the version-map key      $MANIFEST_BASE_NAME-<band>
+# Getting it wrong silently installs the workload where the SDK will never look,
+# so it is worth a real test — especially for new majors such as .NET 11 preview.
+#
+# The bash implementation is extracted from workload-install.sh between the
+# "BEGIN/END VERSION BAND DETECTION" markers so the test always exercises the
+# shipped code rather than a copy.
+#
+# Usage:
+#   bash workload/scripts/test-version-band.sh
+#   make -C workload test-version-band
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SH_SCRIPT="$SCRIPT_DIR/workload-install.sh"
+PS1_SCRIPT="$SCRIPT_DIR/workload-install.ps1"
+
+c_reset=$'\033[0m'; c_red=$'\033[31m'; c_green=$'\033[32m'
+[[ -t 1 ]] || { c_reset=""; c_red=""; c_green=""; }
+
+# --- load the function under test ------------------------------------------
+
+if [[ ! -f "$SH_SCRIPT" ]]; then
+    echo "ERROR: $SH_SCRIPT not found."
+    exit 2
+fi
+
+BAND_FUNC="$(sed -n '/# BEGIN VERSION BAND DETECTION/,/# END VERSION BAND DETECTION/p' "$SH_SCRIPT")"
+if [[ -z "$BAND_FUNC" ]]; then
+    echo "ERROR: VERSION BAND DETECTION markers not found in $SH_SCRIPT."
+    echo "       The install script was edited without keeping the markers intact."
+    exit 2
+fi
+eval "$BAND_FUNC"
+
+# --- cases: "<sdk version>|<expected band>" --------------------------------
+CASES=(
+    # .NET 6 has no preview bands: always rounded to the feature band.
+    "6.0.419|6.0.400"
+    "6.0.100|6.0.100"
+    # Stable bands.
+    "7.0.400|7.0.400"
+    "8.0.404|8.0.400"
+    "9.0.304|9.0.300"
+    "10.0.100|10.0.100"
+    "10.0.400|10.0.400"
+    # Pre-release bands.
+    "7.0.100-preview.6.22352.1|7.0.100-preview.6"
+    "8.0.100-rc.2.23502.2|8.0.100-rc.2"
+    "8.0.100-rtm.23512.16|8.0.100-rtm"
+    "9.0.100-alpha.1.23615.4|9.0.100-alpha.1"
+    "10.0.100-rc.2.25502.107|10.0.100-rc.2"
+    # .NET 11 — the band this repo now supports.
+    "11.0.100-preview.7.26381.103|11.0.100-preview.7"
+    "11.0.100-preview.6.26359.118|11.0.100-preview.6"
+    "11.0.100-rc.1.26500.1|11.0.100-rc.1"
+    "11.0.100|11.0.100"
+    "11.0.200|11.0.200"
+    # Future majors must keep working without another code change.
+    "12.0.100-preview.1.27000.1|12.0.100-preview.1"
+)
+
+pass=0; fail=0
+
+for case in "${CASES[@]}"; do
+    version="${case%%|*}"
+    expected="${case##*|}"
+    actual="$(compute_target_version_band "$version")"
+    if [[ "$actual" == "$expected" ]]; then
+        printf "  %sPASS%s  %-32s -> %s\n" "$c_green" "$c_reset" "$version" "$actual"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-32s -> %s (expected %s)\n" "$c_red" "$c_reset" "$version" "$actual" "$expected"
+        fail=$((fail + 1))
+    fi
+done
+
+# --- parity check: the PowerShell installer must agree ---------------------
+#
+# workload-install.ps1 reimplements the same logic. Run the same cases through
+# pwsh when it is available so the two installers cannot drift apart.
+
+if command -v pwsh >/dev/null 2>&1 && [[ -f "$PS1_SCRIPT" ]]; then
+    echo ""
+    echo "-- PowerShell parity --"
+    for case in "${CASES[@]}"; do
+        version="${case%%|*}"
+        expected="${case##*|}"
+        actual="$(pwsh -NoProfile -Command "
+            \$DotnetVersion = '$version'
+            \$VersionSplitSymbol = '.'
+            \$SplitVersion = \$DotnetVersion.Split(\$VersionSplitSymbol)
+            \$CurrentDotnetVersion = [Version]\"\$(\$SplitVersion[0]).\$(\$SplitVersion[1])\"
+            \$DotnetVersionBand = \$SplitVersion[0] + \$VersionSplitSymbol + \$SplitVersion[1] + \$VersionSplitSymbol + \$SplitVersion[2][0] + '00'
+            \$DotnetTargetVersionBand = \$DotnetVersionBand
+            if (\$CurrentDotnetVersion -ge [Version]'7.0') {
+                \$IsPreviewVersion = \$DotnetVersion.Contains('-preview') -or \$DotnetVersion.Contains('-rc') -or \$DotnetVersion.Contains('-alpha')
+                if (\$IsPreviewVersion -and (\$SplitVersion.Count -ge 4)) {
+                    \$DotnetTargetVersionBand = \$DotnetVersionBand + \$SplitVersion[2].SubString(3) + \$VersionSplitSymbol + \$(\$SplitVersion[3])
+                }
+                elseif (\$DotnetVersion.Contains('-rtm') -and (\$SplitVersion.Count -ge 3)) {
+                    \$DotnetTargetVersionBand = \$DotnetVersionBand + \$SplitVersion[2].SubString(3)
+                }
+            }
+            Write-Output \$DotnetTargetVersionBand" 2>/dev/null | tr -d '\r')"
+        if [[ "$actual" == "$expected" ]]; then
+            printf "  %sPASS%s  %-32s -> %s\n" "$c_green" "$c_reset" "$version" "$actual"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  %-32s -> %s (expected %s)\n" "$c_red" "$c_reset" "$version" "$actual" "$expected"
+            fail=$((fail + 1))
+        fi
+    done
+else
+    echo ""
+    echo "  (pwsh not available - skipping workload-install.ps1 parity check)"
+fi
+
+echo ""
+echo "================ version-band summary ================"
+echo "  passed: $pass"
+echo "  failed: $fail"
+
+[[ $fail -eq 0 ]] || exit 1
+exit 0

--- a/workload/scripts/test-version-band.sh
+++ b/workload/scripts/test-version-band.sh
@@ -139,33 +139,99 @@ fi
 echo ""
 echo "-- fallback band family --"
 
-FALLBACK_CASES=(
-    "samsung.net.sdk.tizen.manifest-11.0.100-preview.7|samsung.net.sdk.tizen.manifest-11.0."
-    "samsung.net.sdk.tizen.manifest-10.0.300|samsung.net.sdk.tizen.manifest-10.0."
-    "samsung.net.sdk.tizen.manifest-9.0.100-rc.1|samsung.net.sdk.tizen.manifest-9.0."
-    "samsung.net.sdk.tizen.manifest-6.0.400|samsung.net.sdk.tizen.manifest-6.0."
+# The SHIPPED resolver is extracted and invoked directly. The previous version of this
+# block re-implemented the family-prefix rule with its own sed, so it agreed with itself
+# no matter what workload-install.sh actually did - it could never detect drift.
+RESOLVER="$(sed -n '/^MANIFEST_BASE_NAME=/p;/# BEGIN AUTO-GENERATED VERSION MAP/,/# END AUTO-GENERATED VERSION MAP/p;/# BEGIN VERSION BAND DETECTION/,/# END VERSION BAND DETECTION/p;/# BEGIN FALLBACK RESOLVER/,/# END FALLBACK RESOLVER/p' "$SH_SCRIPT")"
+eval "$RESOLVER"
+
+if ! declare -f getLatestVersion >/dev/null; then
+    printf "  %sFAIL%s  %s\n" "$c_red" "$c_reset" "could not extract getLatestVersion from workload-install.sh"
+    fail=$((fail + 1))
+else
+    printf "  %sPASS%s  %s\n" "$c_green" "$c_reset" "the shipped resolver is the one under test"
+    pass=$((pass + 1))
+fi
+
+M="samsung.net.sdk.tizen.manifest"
+
+# id|expected resolver output ('' means must fail closed)
+RESOLVER_CASES=(
+    # exact hits come straight from the map
+    "$M-10.0.100|$M-10.0.100=10.0.123"
+    "$M-6.0.400|$M-6.0.400=9.0.104"
+    # closest band AT OR BELOW the request - never a newer one
+    "$M-10.0.200|$M-10.0.100=10.0.123"
+    "$M-10.0.400|$M-10.0.300=10.0.127"
+    "$M-9.0.400|$M-9.0.300=10.0.121"
+    # must never cross the major.minor family
+    "$M-11.0.100-preview.7|"
+    "$M-11.0.100|"
+    # nothing older exists in the family
+    "$M-6.0.050|"
+    # unparseable family fails closed rather than guessing
+    "$M-bogus|"
 )
 
-for case in "${FALLBACK_CASES[@]}"; do
-    mid="${case%%|*}"
+for case in "${RESOLVER_CASES[@]}"; do
+    id="${case%%|*}"
     want="${case##*|}"
-    family="${mid#*-}"
-    family="$(echo "$family" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')"
-    got="${mid%%-*}-${family}."
+    got="$(getLatestVersion "$id")"
     if [[ "$got" == "$want" ]]; then
-        printf "  %sPASS%s  %-48s -> %s\n" "$c_green" "$c_reset" "$mid" "$got"
+        printf "  %sPASS%s  %-48s -> %s\n" "$c_green" "$c_reset" "$id" "${got:-<none>}"
         pass=$((pass + 1))
     else
-        printf "  %sFAIL%s  %-48s -> %s (expected %s)\n" "$c_red" "$c_reset" "$mid" "$got" "$want"
+        printf "  %sFAIL%s  %-48s -> %s (expected %s)\n" "$c_red" "$c_reset" "$id" "${got:-<none>}" "${want:-<none>}"
         fail=$((fail + 1))
     fi
 done
 
-# The 11.x family prefix must not match any 10.x map key.
-if grep -q 'MANIFEST_BASE_NAME-10\.' "$SH_SCRIPT" && \
-   ! grep -q '"\$MANIFEST_BASE_NAME-11\.0\.' "$SH_SCRIPT"; then
-    printf "  %sPASS%s  %-48s\n" "$c_green" "$c_reset" "11.0 family has no map entry (fallback must fail closed)"
-    pass=$((pass + 1))
+# --- SemVer ordering of pre-release bands -------------------------------------
+#
+# band_sort_key appended the pre-release raw and the comparison is a string compare, so
+# "preview.10" sorted BELOW "preview.9" ('1' < '9'). A request against a preview.10 band
+# would then fall back to preview.9. Ordering is asserted on the real function.
+
+echo ""
+echo "-- SemVer band ordering --"
+
+ORDERED=(
+    "8.0.100-alpha.1"
+    "11.0.100-preview.7"
+    "11.0.100-preview.9"
+    "11.0.100-preview.10"
+    "11.0.100-rc.1"
+    "11.0.100-rtm"
+    "11.0.100"
+)
+prev=""
+prev_band=""
+for band in "${ORDERED[@]}"; do
+    key="$(band_sort_key "$band")"
+    if [[ -z "$prev" || "$key" > "$prev" ]]; then
+        printf "  %sPASS%s  %-24s sorts above %s\n" "$c_green" "$c_reset" "$band" "${prev_band:-<start>}"
+        pass=$((pass + 1))
+    else
+        printf "  %sFAIL%s  %-24s does NOT sort above %s\n" "$c_red" "$c_reset" "$band" "$prev_band"
+        fail=$((fail + 1))
+    fi
+    prev="$key"; prev_band="$band"
+done
+
+# sh/ps1 parity on the real functions, not on a description of them.
+if command -v pwsh >/dev/null 2>&1; then
+    PS_KEYFUNC="$(sed -n '/function Get-BandSortKey/,/^}/p' "$PS1_SCRIPT")"
+    for band in "${ORDERED[@]}"; do
+        sh_key="$(band_sort_key "$band")"
+        ps_key="$(pwsh -NoProfile -Command "$PS_KEYFUNC; Get-BandSortKey -Band '$band'" 2>/dev/null | tr -d '\r')"
+        if [[ "$sh_key" == "$ps_key" ]]; then
+            printf "  %sPASS%s  %-24s sh/ps1 key parity\n" "$c_green" "$c_reset" "$band"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  %-24s sh=%s ps1=%s\n" "$c_red" "$c_reset" "$band" "$sh_key" "$ps_key"
+            fail=$((fail + 1))
+        fi
+    done
 fi
 
 # --- producer/consumer parity: Config.mk must agree with the installers -------
@@ -214,6 +280,35 @@ if command -v make >/dev/null 2>&1; then
             pass=$((pass + 1))
         else
             printf "  %sFAIL%s  %-24s same for both bands (%s)\n" "$c_red" "$c_reset" "$var" "$a"
+            fail=$((fail + 1))
+        fi
+    done
+
+    # Isolation must also hold WITHIN a band. 10.0.100 and 10.0.101 share a feature band,
+    # so a band-keyed cache handed the second one the first one's SDK - the build then
+    # silently tested an SDK it was never asked for. The SDK directory and stamp are keyed
+    # by the FULL version; only the manifest path stays band-based.
+    for pair in "10.0.100|10.0.101" "11.0.100-preview.7.26381.103|11.0.100-preview.7.26999.1"; do
+        v1="${pair%%|*}"; v2="${pair##*|}"
+        for var in print-dotnet-destdir print-install-stamp; do
+            a="$(DOTNET_VERSION=$v1 make -s -C "$WORKLOAD_DIR" $var 2>/dev/null | tail -1)"
+            b="$(DOTNET_VERSION=$v2 make -s -C "$WORKLOAD_DIR" $var 2>/dev/null | tail -1)"
+            if [[ -n "$a" && -n "$b" && "$a" != "$b" ]]; then
+                printf "  %sPASS%s  %-24s differs for %s vs %s\n" "$c_green" "$c_reset" "$var" "$v1" "$v2"
+                pass=$((pass + 1))
+            else
+                printf "  %sFAIL%s  %-24s identical for %s and %s (%s)\n" "$c_red" "$c_reset" "$var" "$v1" "$v2" "$a"
+                fail=$((fail + 1))
+            fi
+        done
+        # ...while the manifest band deliberately stays shared.
+        ba="$(DOTNET_VERSION=$v1 make -s -C "$WORKLOAD_DIR" print-version-band 2>/dev/null | tail -1)"
+        bb="$(DOTNET_VERSION=$v2 make -s -C "$WORKLOAD_DIR" print-version-band 2>/dev/null | tail -1)"
+        if [[ -n "$ba" && "$ba" == "$bb" ]]; then
+            printf "  %sPASS%s  %-24s shared by %s and %s (%s)\n" "$c_green" "$c_reset" "manifest band" "$v1" "$v2" "$ba"
+            pass=$((pass + 1))
+        else
+            printf "  %sFAIL%s  %-24s %s=%s but %s=%s\n" "$c_red" "$c_reset" "manifest band" "$v1" "$ba" "$v2" "$bb"
             fail=$((fail + 1))
         fi
     done

--- a/workload/scripts/validate-workload-metadata.py
+++ b/workload/scripts/validate-workload-metadata.py
@@ -30,12 +30,17 @@ Checks:
       matching KnownRuntimePack in Samsung.Tizen.Sdk.targets. Without it the SDK
       cannot resolve Samsung.NETCore.App.Runtime.tizen and the build fails with
       NETSDK1082 ("no runtime pack available").
-  C6  Every KnownRuntimePack .NET major has a FileList row in RuntimeList.xml.
+  C6  RuntimeList.xml is well-formed XML with a single <FileList> root. It is parsed by
+      ResolveRuntimePackAssets (e.g. for SelfContained=true), so multiple roots throw a
+      raw XmlException. The pack ships no runtime binaries, so the list is empty and
+      self-contained publishing is rejected by TIZENSDK001 instead.
   C7  DotNet11SdkVersion exists in Versions.props and no workflow hardcodes a
       different .NET 11 SDK version (the workflows must grep the SSOT).
-  C8  PackageTargetFallback covers every (.NET major from KnownRuntimePack) x
-      (platform from TizenSdkSupportedTargetPlatformVersion) combination. A missing
-      entry silently downgrades a package to its netstandard2.x assets.
+  C8  The PackageTargetFallback candidate list covers every (.NET major from
+      KnownRuntimePack) x (platform from TizenSdkSupportedTargetPlatformVersion)
+      combination, and every candidate is emitted with a compatibility Condition.
+      A missing entry silently downgrades a package to its netstandard2.x assets;
+      an unconditional entry lets an incompatible TFM's assets be substituted.
 
 Run from anywhere — paths derive from this script's location.
 
@@ -46,6 +51,7 @@ Exit codes:
 from __future__ import annotations
 import re
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 WORKLOAD_DIR = Path(__file__).resolve().parents[1]
@@ -208,18 +214,33 @@ def main() -> int:
            ") all have a KnownRuntimePack")
 
     # --- C6 ---
-    runtime_list_vers = {
-        "net" + v for v in re.findall(r'TargetFrameworkVersion="([\d.]+)"', runtime_list)
-    }
-    missing_rl = sorted(krp_tfms - runtime_list_vers, key=lambda v: float(v[3:])) if krp_tfms else []
-    if not runtime_list_vers:
-        err("C6: no FileList rows parsed from Samsung.NETCore.App.Runtime/data/RuntimeList.xml")
-    elif missing_rl:
-        err("C6: RuntimeList.xml has no FileList row for " + str(missing_rl) +
-            " but a KnownRuntimePack declares it.")
-    else:
-        ok("C6: KnownRuntimePack majors (" + str(len(krp_tfms)) +
-           ") all present in RuntimeList.xml")
+    rl_path = WORKLOAD_DIR / "src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml"
+    c6_ok = True
+    try:
+        rl_root = ET.parse(rl_path).getroot()
+    except ET.ParseError as exc:
+        err("C6: RuntimeList.xml is not well-formed XML (" + str(exc) + "). "
+            "ResolveRuntimePackAssets parses this file - e.g. for SelfContained=true - and "
+            "multiple roots surface as a raw XmlException.")
+        rl_root = None
+        c6_ok = False
+    if rl_root is not None:
+        if rl_root.tag != "FileList":
+            err("C6: RuntimeList.xml root is <" + rl_root.tag + ">, expected <FileList>")
+            c6_ok = False
+        # The pack is a placeholder with no runtime binaries. If files ever appear here,
+        # the self-contained rejection below needs revisiting.
+        files = rl_root.findall("File")
+        sdk_targets_txt = read("src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets")
+        has_guard = "TIZENSDK001" in sdk_targets_txt
+        if not files and not has_guard:
+            err("C6: RuntimeList.xml lists no runtime files, but Samsung.Tizen.Sdk.targets has "
+                "no TIZENSDK001 self-contained guard. A self-contained publish would emit an "
+                "app with no runtime.")
+            c6_ok = False
+        if c6_ok:
+            ok("C6: RuntimeList.xml well-formed (single <FileList> root, " + str(len(files)) +
+               " file(s)); self-contained guarded by TIZENSDK001")
 
     # --- C7 ---
     net11_sdk = props.get("DotNet11SdkVersion", "")
@@ -230,9 +251,17 @@ def main() -> int:
         workflow_dir = WORKLOAD_DIR.parent / ".github" / "workflows"
         stray = []
         for wf in sorted(workflow_dir.glob("*.yml")):
-            text = wf.read_text(encoding="utf-8")
-            for literal in set(re.findall(r"\b11\.0\.\d{3}-[A-Za-z0-9.]+", text)):
-                if literal != net11_sdk:
+            # Strip comments: prose may legitimately mention a band or an example
+            # version. Only real values can cause CI to use the wrong SDK.
+            lines = []
+            for line in wf.read_text(encoding="utf-8").splitlines():
+                stripped = line.lstrip()
+                if stripped.startswith("#"):
+                    continue
+                lines.append(line.split(" #", 1)[0])
+            text = "\n".join(lines)
+            for literal in set(re.findall(r"\b11\.0\.\d{3}-[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*", text)):
+                if literal.rstrip(".") != net11_sdk:
                     stray.append(wf.name + ": " + literal)
         if stray:
             err("C7: workflow(s) hardcode a .NET 11 SDK version differing from "
@@ -242,25 +271,36 @@ def main() -> int:
 
     # --- C8 ---
     nuget_targets = read("src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets")
-    ptf_match = re.search(r"<PackageTargetFallback>(.*?)</PackageTargetFallback>",
-                          nuget_targets, re.S)
-    if not ptf_match:
-        err("C8: PackageTargetFallback not found in Samsung.Tizen.Sdk.NuGet.targets")
+    # Each candidate is a conditional _TizenFallbackList append. Capture the appended TFM
+    # and whether the line carries a compatibility Condition.
+    cand_lines = re.findall(
+        r'<_TizenFallbackList(\s+Condition="[^"]*")?>\$\(_TizenFallbackList\);([^<]+)</_TizenFallbackList>',
+        nuget_targets)
+    if not cand_lines:
+        err("C8: no _TizenFallbackList candidates found in Samsung.Tizen.Sdk.NuGet.targets")
     elif not krp_tfms or not supported_set:
         err("C8: cannot evaluate - KnownRuntimePack or supported platform list empty")
     else:
-        listed = set(
-            e.strip() for e in ptf_match.group(1).replace("\n", "").split(";") if e.strip()
-        )
+        listed = {tfm.strip() for _cond, tfm in cand_lines}
+        unconditional = sorted(tfm.strip() for cond, tfm in cand_lines if not cond)
         expected = {m + "-tizen" + p for m in krp_tfms for p in supported_set}
         missing_ptf = sorted(expected - listed)
+        c8_ok = True
         if missing_ptf:
             err("C8: PackageTargetFallback missing " + str(missing_ptf) +
                 ". A package shipping lib/<tfm>/ alongside netstandard2.x would silently "
                 "resolve to the netstandard assets for those TFMs.")
-        else:
+            c8_ok = False
+        if unconditional:
+            err("C8: PackageTargetFallback candidate(s) " + str(unconditional) +
+                " have no compatibility Condition. FixupNuGetReferences matches by name "
+                "only, so an unconditional entry lets an incompatible TFM's assets be "
+                "substituted (e.g. net6.0-tizen11.0 into a net6.0-tizen8.0 build).")
+            c8_ok = False
+        if c8_ok:
             ok("C8: PackageTargetFallback covers all " + str(len(expected)) +
-               " supported (.NET major x platform) combinations")
+               " supported (.NET major x platform) combinations; all " +
+               str(len(cand_lines)) + " candidates are compatibility-gated")
 
     print()
     if errors:

--- a/workload/scripts/validate-workload-metadata.py
+++ b/workload/scripts/validate-workload-metadata.py
@@ -31,6 +31,11 @@ Checks:
       cannot resolve Samsung.NETCore.App.Runtime.tizen and the build fails with
       NETSDK1082 ("no runtime pack available").
   C6  Every KnownRuntimePack .NET major has a FileList row in RuntimeList.xml.
+  C7  DotNet11SdkVersion exists in Versions.props and no workflow hardcodes a
+      different .NET 11 SDK version (the workflows must grep the SSOT).
+  C8  PackageTargetFallback covers every (.NET major from KnownRuntimePack) x
+      (platform from TizenSdkSupportedTargetPlatformVersion) combination. A missing
+      entry silently downgrades a package to its netstandard2.x assets.
 
 Run from anywhere — paths derive from this script's location.
 
@@ -215,6 +220,47 @@ def main() -> int:
     else:
         ok("C6: KnownRuntimePack majors (" + str(len(krp_tfms)) +
            ") all present in RuntimeList.xml")
+
+    # --- C7 ---
+    net11_sdk = props.get("DotNet11SdkVersion", "")
+    if not net11_sdk:
+        err("C7: <DotNet11SdkVersion> missing from Versions.props; CI resolves the .NET 11 "
+            "SDK by grepping it")
+    else:
+        workflow_dir = WORKLOAD_DIR.parent / ".github" / "workflows"
+        stray = []
+        for wf in sorted(workflow_dir.glob("*.yml")):
+            text = wf.read_text(encoding="utf-8")
+            for literal in set(re.findall(r"\b11\.0\.\d{3}-[A-Za-z0-9.]+", text)):
+                if literal != net11_sdk:
+                    stray.append(wf.name + ": " + literal)
+        if stray:
+            err("C7: workflow(s) hardcode a .NET 11 SDK version differing from "
+                "DotNet11SdkVersion (" + net11_sdk + "): " + str(sorted(stray)))
+        else:
+            ok("C7: DotNet11SdkVersion = " + net11_sdk + "; no conflicting workflow literals")
+
+    # --- C8 ---
+    nuget_targets = read("src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets")
+    ptf_match = re.search(r"<PackageTargetFallback>(.*?)</PackageTargetFallback>",
+                          nuget_targets, re.S)
+    if not ptf_match:
+        err("C8: PackageTargetFallback not found in Samsung.Tizen.Sdk.NuGet.targets")
+    elif not krp_tfms or not supported_set:
+        err("C8: cannot evaluate - KnownRuntimePack or supported platform list empty")
+    else:
+        listed = set(
+            e.strip() for e in ptf_match.group(1).replace("\n", "").split(";") if e.strip()
+        )
+        expected = {m + "-tizen" + p for m in krp_tfms for p in supported_set}
+        missing_ptf = sorted(expected - listed)
+        if missing_ptf:
+            err("C8: PackageTargetFallback missing " + str(missing_ptf) +
+                ". A package shipping lib/<tfm>/ alongside netstandard2.x would silently "
+                "resolve to the netstandard assets for those TFMs.")
+        else:
+            ok("C8: PackageTargetFallback covers all " + str(len(expected)) +
+               " supported (.NET major x platform) combinations")
 
     print()
     if errors:

--- a/workload/scripts/validate-workload-metadata.py
+++ b/workload/scripts/validate-workload-metadata.py
@@ -14,6 +14,9 @@ Validates that the following stay in sync:
   workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets.in
   workload/src/Samsung.NET.Sdk.Tizen/WorkloadManifest.in.json
   workload/scripts/test-matrix.sh
+  workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
+  workload/src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml
+  workload/src/Samsung.Tizen.Templates/tizen/.template.config/template.json
 
 Checks:
   C1  Versions.targets.in sigils all have matching Versions.props property
@@ -23,6 +26,11 @@ Checks:
   C3  TizenSdkSupportedTargetPlatformVersion ↔ KnownFrameworkReference
       consistency in Versions.targets.in.
   C4  test-matrix.sh MATRIX uses only supported platforms.
+  C5  Every .NET major offered by the template / exercised by test-matrix.sh has a
+      matching KnownRuntimePack in Samsung.Tizen.Sdk.targets. Without it the SDK
+      cannot resolve Samsung.NETCore.App.Runtime.tizen and the build fails with
+      NETSDK1082 ("no runtime pack available").
+  C6  Every KnownRuntimePack .NET major has a FileList row in RuntimeList.xml.
 
 Run from anywhere — paths derive from this script's location.
 
@@ -85,6 +93,9 @@ def main() -> int:
     versions_in = read("src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.Versions.targets.in")
     workload_in = read("src/Samsung.NET.Sdk.Tizen/WorkloadManifest.in.json")
     matrix_sh = read("scripts/test-matrix.sh")
+    sdk_targets = read("src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets")
+    runtime_list = read("src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml")
+    template_json = read("src/Samsung.Tizen.Templates/tizen/.template.config/template.json")
 
     sdk_repl = parse_replacements(sdk_proj)
     manifest_repl = parse_replacements(manifest_proj)
@@ -161,6 +172,49 @@ def main() -> int:
         err("C4: test-matrix.sh uses unsupported platform(s): " + str(sorted(unknown_plats)))
     else:
         ok("C4: test-matrix.sh (" + str(len(matrix_entries)) + " rows) all platforms supported")
+
+    # --- C5 ---
+    # KnownRuntimePack is keyed by the .NET major TFM (net8.0, net10.0, ...).
+    # A TFM the template can produce but the SDK has no runtime pack for fails at
+    # build time, so both producers of TFMs must be covered.
+    krp_tfms = set(
+        re.findall(r'<KnownRuntimePack\b[^>]*?\n?[^>]*?TargetFramework="(net[\d.]+)"', sdk_targets)
+    )
+    if not krp_tfms:
+        # Attribute order/newlines vary; fall back to a per-element scan.
+        for block in re.findall(r"<KnownRuntimePack\b.*?/>", sdk_targets, re.S):
+            m = re.search(r'TargetFramework="(net[\d.]+)"', block)
+            if m:
+                krp_tfms.add(m.group(1))
+
+    template_netvers = set(re.findall(r'"choice":\s*"(net[\d.]+)"', template_json))
+    matrix_netvers = {tfm.split("-tizen", 1)[0] for tfm, _api in matrix_entries}
+    required_netvers = template_netvers | matrix_netvers
+
+    missing_krp = sorted(required_netvers - krp_tfms, key=lambda v: float(v[3:]))
+    if not krp_tfms:
+        err("C5: no KnownRuntimePack entries parsed from Samsung.Tizen.Sdk.targets")
+    elif missing_krp:
+        err("C5: no KnownRuntimePack for " + str(missing_krp) +
+            " (offered by template.json / test-matrix.sh). Add a KnownRuntimePack "
+            "entry in Samsung.Tizen.Sdk.targets or the build fails with NETSDK1082.")
+    else:
+        ok("C5: template/test-matrix .NET majors (" + str(len(required_netvers)) +
+           ") all have a KnownRuntimePack")
+
+    # --- C6 ---
+    runtime_list_vers = {
+        "net" + v for v in re.findall(r'TargetFrameworkVersion="([\d.]+)"', runtime_list)
+    }
+    missing_rl = sorted(krp_tfms - runtime_list_vers, key=lambda v: float(v[3:])) if krp_tfms else []
+    if not runtime_list_vers:
+        err("C6: no FileList rows parsed from Samsung.NETCore.App.Runtime/data/RuntimeList.xml")
+    elif missing_rl:
+        err("C6: RuntimeList.xml has no FileList row for " + str(missing_rl) +
+            " but a KnownRuntimePack declares it.")
+    else:
+        ok("C6: KnownRuntimePack majors (" + str(len(krp_tfms)) +
+           ") all present in RuntimeList.xml")
 
     print()
     if errors:

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -27,7 +27,6 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 $ManifestBaseName = "Samsung.NET.Sdk.Tizen.Manifest"
-$global:FallbackId = ""
 
 # BEGIN AUTO-GENERATED VERSION MAP -- edit version-map.json and rerun Generate-InstallScripts.ps1
 $LatestVersionMap = [ordered]@{
@@ -96,7 +95,7 @@ function Get-LatestVersion([string]$Id) {
         try
         {
             $Response = Invoke-WebRequest -Uri https://api.nuget.org/v3-flatcontainer/$($Id.ToLowerInvariant())/index.json -UseBasicParsing | ConvertFrom-Json
-            return $Response.versions | Select-Object -Last 1
+            return "$Id=$($Response.versions | Select-Object -Last 1)"
         }
         catch {
             Write-Host "Id: $Id"
@@ -110,7 +109,7 @@ function Get-LatestVersion([string]$Id) {
     if ($LatestVersionMap.Contains($Id))
     {
         Write-Host "Return cached latest version."
-        return $LatestVersionMap.$Id
+        return "$Id=$($LatestVersionMap.$Id)"
     }
     else
     {
@@ -132,10 +131,10 @@ function Get-LatestVersion([string]$Id) {
             }
             if ($MatchingFallbackVersion)
             {
-                $global:FallbackId = $MatchingFallbackId[-1]
+                $FallbackId = $MatchingFallbackId[-1]
                 $FallbackVersion = $MatchingFallbackVersion[-1]
-                Write-Host "Return fallback version: $FallbackVersion (from $($MatchingFallbackId[-1]))"
-                return $FallbackVersion
+                Write-Host "Return fallback version: $FallbackVersion (from $FallbackId)"
+                return "$FallbackId=$FallbackVersion"
             }
         }
     }
@@ -249,8 +248,19 @@ function Install-TizenWorkload([string]$DotnetVersion)
     }
 
     # Check latest version of manifest.
+    #
+    # Get-LatestVersion returns "<packageId>=<version>". The id matters: when the
+    # requested band has no published manifest we fall back to an earlier band's
+    # package, and that version does not exist under the requested id. Both values are
+    # kept function-local so an -UpdateAllWorkloads run cannot carry one SDK's fallback
+    # package into the next SDK's install.
     if ($Version -eq "<latest>" -or $UpdateAllWorkloads.IsPresent) {
-        $Version = Get-LatestVersion -Id $ManifestName
+        $Resolved = Get-LatestVersion -Id $ManifestName
+        if (-not $Resolved) {
+            throw "Failed to resolve a manifest package for $ManifestName."
+        }
+        $ManifestName = $Resolved.Substring(0, $Resolved.LastIndexOf("="))
+        $Version = $Resolved.Substring($Resolved.LastIndexOf("=") + 1)
     }
 
     # Check workload manifest directory.
@@ -285,11 +295,7 @@ function Install-TizenWorkload([string]$DotnetVersion)
 
     # Install workload manifest.
     Write-Host "Installing $ManifestName/$Version to $ManifestDir..."
-    if ($global:FallbackId) {
-        Install-Pack -Id $global:FallbackId -Version $Version -Kind "manifest"
-    } else {
-        Install-Pack -Id $ManifestName -Version $Version -Kind "manifest"
-    }
+    Install-Pack -Id $ManifestName -Version $Version -Kind "manifest"
 
     # Download and install workload packs.
     $NewManifestJson = $(Get-Content $TizenManifestFile | ConvertFrom-Json)

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -304,7 +304,7 @@ if (Get-Command $DotnetCommand -ErrorAction SilentlyContinue)
 {
     if ($UpdateAllWorkloads.IsPresent)
     {
-        $InstalledDotnetSdks = Invoke-Expression "& '$DotnetCommand' --list-sdks | Select-String -Pattern '^6|^7'" | ForEach-Object {$_ -replace (" \[.*","")}
+        $InstalledDotnetSdks = Invoke-Expression "& '$DotnetCommand' --list-sdks | Select-String -Pattern '^([6-9]|[1-9][0-9]+)\.'" | ForEach-Object {$_ -replace (" \[.*","")}
     }
     else
     {
@@ -329,4 +329,11 @@ else
             Install-TizenWorkload -DotnetVersion $DotnetSdk
         }
         catch {
-            Write-Host 
+            Write-Host "Failed to install Tizen Workload for sdk $DotnetSdk"
+            Write-Host "$_"
+            Continue
+        }
+    }
+}
+
+Write-Host "`nDone"

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -95,7 +95,16 @@ function Get-LatestVersion([string]$Id) {
         try
         {
             $Response = Invoke-WebRequest -Uri https://api.nuget.org/v3-flatcontainer/$($Id.ToLowerInvariant())/index.json -UseBasicParsing | ConvertFrom-Json
-            return "$Id=$($Response.versions | Select-Object -Last 1)"
+            $Selected = $Response.versions | Where-Object { $_ -and $_.Trim() } | Select-Object -Last 1
+            if ($Selected) {
+                return "$Id=$($Selected.Trim())"
+            }
+            # An empty or all-blank versions[] is NOT a usable answer. Returning "$Id="
+            # here would be truthy, and the NuGet v2 package endpoint serves the LATEST
+            # version when given a versionless URL - silently installing an arbitrary
+            # package. Fall through to the retry/version-map path instead.
+            Write-Host "Id: $Id"
+            Write-Host "The feed returned no usable versions."
         }
         catch {
             Write-Host "Id: $Id"
@@ -256,11 +265,19 @@ function Install-TizenWorkload([string]$DotnetVersion)
     # package into the next SDK's install.
     if ($Version -eq "<latest>" -or $UpdateAllWorkloads.IsPresent) {
         $Resolved = Get-LatestVersion -Id $ManifestName
-        if (-not $Resolved) {
+        if (-not $Resolved -or -not $Resolved.Contains("=")) {
             throw "Failed to resolve a manifest package for $ManifestName."
         }
-        $ManifestName = $Resolved.Substring(0, $Resolved.LastIndexOf("="))
-        $Version = $Resolved.Substring($Resolved.LastIndexOf("=") + 1)
+        $ResolvedId      = $Resolved.Substring(0, $Resolved.LastIndexOf("="))
+        $ResolvedVersion = $Resolved.Substring($Resolved.LastIndexOf("=") + 1)
+        # Defence in depth: never proceed with an empty version. The NuGet v2 package
+        # endpoint serves the LATEST version when the URL has no version segment, so an
+        # empty value would silently install an arbitrary package.
+        if ([string]::IsNullOrWhiteSpace($ResolvedId) -or [string]::IsNullOrWhiteSpace($ResolvedVersion)) {
+            throw "Resolved an invalid manifest package '$Resolved' for $ManifestName."
+        }
+        $ManifestName = $ResolvedId
+        $Version      = $ResolvedVersion
     }
 
     # Check workload manifest directory.

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -260,8 +260,22 @@ function Get-BandSortKey([string]$Band)
     $Parts = $Core.Split('.')
     $Major = [int]($Parts[0]); $Minor = [int]($Parts[1]); $Patch = [int]($Parts[2])
     if ($Pre) {
-        return ('{0:D5}{1:D5}{2:D5}0{3}' -f $Major, $Minor, $Patch, $Pre)
+        # Normalise the pre-release so a plain string comparison follows SemVer precedence.
+        # Appending it raw made the comparison lexicographic, where "preview.10" sorts
+        # BELOW "preview.9" because '1' < '9'. Numeric identifiers are zero-padded and
+        # tagged 0, alphanumeric ones tagged 1 (numeric < alphanumeric in SemVer).
+        # Must stay byte-identical to band_sort_key() in workload-install.sh.
+        $Normalised = ""
+        foreach ($Ident in $Pre.Split('.')) {
+            if ($Ident -match '^[0-9]+$') {
+                $Normalised += '.' + ('0{0:D10}' -f [int]$Ident)
+            } else {
+                $Normalised += '.1' + $Ident
+            }
+        }
+        return ('{0:D5}{1:D5}{2:D5}0{3}' -f $Major, $Minor, $Patch, $Normalised)
     }
+    # No pre-release: sorts above every pre-release of the same core version.
     return ('{0:D5}{1:D5}{2:D5}1' -f $Major, $Minor, $Patch)
 }
 
@@ -278,8 +292,12 @@ function Install-TizenWorkload([string]$DotnetVersion)
 
     if ($DotnetTargetVersionBand -eq "<auto>" -or $UpdateAllWorkloads.IsPresent) {
         $DotnetTargetVersionBand = Get-TargetVersionBand -DotnetVersion $DotnetVersion
-        $ManifestName = "$ManifestBaseName-$DotnetTargetVersionBand"
     }
+    # The manifest package is named after the band it is FOR, so it must always follow the
+    # target band - including an explicitly requested one. Deriving it from the running SDK
+    # meant `-Tizen 10.0.200` on a 10.0.100 SDK downloaded the 10.0.100 manifest and
+    # installed it into sdk-manifests\10.0.200. Matches workload-install.sh.
+    $ManifestName = "$ManifestBaseName-$DotnetTargetVersionBand"
 
     # Check latest version of manifest.
     #
@@ -348,27 +366,53 @@ function Install-TizenWorkload([string]$DotnetVersion)
     Ensure-Directory $ManifestDir
     $TempDir = $(New-TemporaryDirectory)
 
-    # Install workload manifest.
-    Write-Host "Installing $ManifestName/$Version to $ManifestDir..."
-    Install-Pack -Id $ManifestName -Version $Version -Kind "manifest"
-
-    # Download and install workload packs.
-    $NewManifestJson = $(Get-Content $TizenManifestFile | ConvertFrom-Json)
-    $NewManifestJson.packs.PSObject.Properties | ForEach-Object {
-        Write-Host "Installing $($_.Name)/$($_.Value.version)..."
-        Install-Pack -Id $_.Name -Version $_.Value.version -Kind $_.Value.kind
+    # The remove-then-install sequence below is destructive: the previous manifest and its
+    # packs are deleted BEFORE the new ones are fetched, so any failure in between used to
+    # leave the SDK with no Tizen workload at all - a worse state than before the run. The
+    # whole sequence is therefore one transaction, and the previous manifest is restored on
+    # any failure. Matches the tx_rollback handling in workload-install.sh.
+    $TxBackupDir = $null
+    if (Test-Path $TizenManifestDir) {
+        $TxBackupDir = Join-Path -Path $TempDir -ChildPath "manifest-backup"
+        Copy-Item -Path $TizenManifestDir -Destination $TxBackupDir -Recurse -Force
     }
+    $TxCommitted = $false
 
-    # Add tizen to the installed workload metadata.
-    # Featured version band for metadata does NOT include any preview specifier.
-    # https://github.com/dotnet/sdk/blob/main/documentation/general/workloads/user-local-workloads.md
-    New-Item -Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstalledWorkloads\tizen") -Force | Out-Null
-    if (Test-Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstallerType\msi")) {
-        New-Item -Path "HKLM:\SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\x64\$DotnetTargetVersionBand\tizen" -Force | Out-Null
+    try {
+        # Install workload manifest.
+        Write-Host "Installing $ManifestName/$Version to $ManifestDir..."
+        Install-Pack -Id $ManifestName -Version $Version -Kind "manifest"
+
+        # Download and install workload packs.
+        $NewManifestJson = $(Get-Content $TizenManifestFile | ConvertFrom-Json)
+        $NewManifestJson.packs.PSObject.Properties | ForEach-Object {
+            Write-Host "Installing $($_.Name)/$($_.Value.version)..."
+            Install-Pack -Id $_.Name -Version $_.Value.version -Kind $_.Value.kind
+        }
+
+        # Add tizen to the installed workload metadata.
+        # Featured version band for metadata does NOT include any preview specifier.
+        # https://github.com/dotnet/sdk/blob/main/documentation/general/workloads/user-local-workloads.md
+        New-Item -Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstalledWorkloads\tizen") -Force | Out-Null
+        if (Test-Path $(Join-Path -Path $DotnetInstallDir -ChildPath "metadata\workloads\$DotnetVersionBand\InstallerType\msi")) {
+            New-Item -Path "HKLM:\SOFTWARE\Microsoft\dotnet\InstalledWorkloads\Standalone\x64\$DotnetTargetVersionBand\tizen" -Force | Out-Null
+        }
+        $TxCommitted = $true
     }
-
-    # Clean up
-    Remove-Item -Path $TempDir -Force -Recurse
+    finally {
+        if (-not $TxCommitted) {
+            Write-Host "Install failed; rolling back the Tizen manifest."
+            if (Test-Path $TizenManifestDir) {
+                Remove-Item -Path $TizenManifestDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+            if ($TxBackupDir -and (Test-Path $TxBackupDir)) {
+                Ensure-Directory $ManifestDir
+                Copy-Item -Path $TxBackupDir -Destination $TizenManifestDir -Recurse -Force
+            }
+        }
+        # Clean up
+        if (Test-Path $TempDir) { Remove-Item -Path $TempDir -Force -Recurse }
+    }
 
     Write-Host "Done installing Tizen workload $Version"
 }

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -130,18 +130,28 @@ function Get-LatestVersion([string]$Id) {
         $BandPrefix = Get-BandFamilyPrefix -ManifestId $Id
         if ($BandPrefix)
         {
-            $MatchingFallbackId = @()
-            $MatchingFallbackVersion = @()
+            # Choose the CLOSEST band <= the requested one. Taking the last/highest match
+            # meant a request for 10.0.200 resolved to 10.0.300 - a NEWER band, whose
+            # manifest may not be valid for the requested SDK - while skipping a perfectly
+            # good 10.0.200 or 10.0.100. Must match getLatestVersion in workload-install.sh.
+            $RequestedBand = $Id.Substring($Id.IndexOf("-") + 1)
+            $RequestedKey  = Get-BandSortKey -Band $RequestedBand
+            $FallbackId = ""
+            $FallbackVersion = ""
+            $BestKey = ""
             foreach ($key in $LatestVersionMap.Keys) {
-                if ($key -like "$BandPrefix*") {
-                    $MatchingFallbackId += $key
-                    $MatchingFallbackVersion += $LatestVersionMap[$key]
+                if ($key -notlike "$BandPrefix*") { continue }
+                $CandidateBand = $key.Substring($key.IndexOf("-") + 1)
+                $CandidateKey  = Get-BandSortKey -Band $CandidateBand
+                if ([string]::Compare($CandidateKey, $RequestedKey, $false) -gt 0) { continue }
+                if ($BestKey -eq "" -or [string]::Compare($CandidateKey, $BestKey, $false) -gt 0) {
+                    $BestKey = $CandidateKey
+                    $FallbackId = $key
+                    $FallbackVersion = $LatestVersionMap[$key]
                 }
             }
-            if ($MatchingFallbackVersion)
+            if ($FallbackId)
             {
-                $FallbackId = $MatchingFallbackId[-1]
-                $FallbackVersion = $MatchingFallbackVersion[-1]
                 Write-Host "Return fallback version: $FallbackVersion (from $FallbackId)"
                 return "$FallbackId=$FallbackVersion"
             }
@@ -240,6 +250,21 @@ function Get-BandFamilyPrefix([string]$ManifestId)
     if (-not $Match.Success) { return "" }
     return $ManifestId.Substring(0, $ManifestId.IndexOf("-") + 1) + $Match.Groups[1].Value + "."
 }
+# Comparable sort key for an SDK feature band, e.g. '10.0.300' or '11.0.100-preview.7'.
+# Zero-padded so ordinal string comparison orders bands correctly, with pre-release bands
+# sorting BEFORE the corresponding stable band ('0' < '1').
+function Get-BandSortKey([string]$Band)
+{
+    $Core = $Band.Split('-')[0]
+    $Pre  = if ($Band.Contains('-')) { $Band.Substring($Band.IndexOf('-') + 1) } else { "" }
+    $Parts = $Core.Split('.')
+    $Major = [int]($Parts[0]); $Minor = [int]($Parts[1]); $Patch = [int]($Parts[2])
+    if ($Pre) {
+        return ('{0:D5}{1:D5}{2:D5}0{3}' -f $Major, $Minor, $Patch, $Pre)
+    }
+    return ('{0:D5}{1:D5}{2:D5}1' -f $Major, $Minor, $Patch)
+}
+
 # END VERSION BAND DETECTION
 
 function Install-TizenWorkload([string]$DotnetVersion)

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -114,21 +114,29 @@ function Get-LatestVersion([string]$Id) {
     }
     else
     {
-        $SubStringId = $Id.Substring(0, $ManifestBaseName.Length + 2);
-        $MatchingFallbackId = @()
-        $MatchingFallbackVersion = @()
-        foreach ($key in $LatestVersionMap.Keys) {
-            if ($key -like "$SubStringId*") {
-                $MatchingFallbackId += $key
-                $MatchingFallbackVersion += $LatestVersionMap[$key]
-            }
-        }
-        if ($MatchingFallbackVersion)
+        # Only fall back within the SAME .NET major.minor family.
+        #
+        # This used to take a fixed-length prefix ($ManifestBaseName.Length + 2), which for
+        # '...Manifest-11.0.100-preview.7' yields '...Manifest-1' and therefore matches the
+        # 10.x entries too - silently installing a .NET 10 manifest into an 11.x band.
+        $BandPrefix = Get-BandFamilyPrefix -ManifestId $Id
+        if ($BandPrefix)
         {
-            $global:FallbackId = $MatchingFallbackId[-1]
-            $FallbackVersion = $MatchingFallbackVersion[-1]
-            Write-Host "Return fallback version: $FallbackVersion"
-            return $FallbackVersion
+            $MatchingFallbackId = @()
+            $MatchingFallbackVersion = @()
+            foreach ($key in $LatestVersionMap.Keys) {
+                if ($key -like "$BandPrefix*") {
+                    $MatchingFallbackId += $key
+                    $MatchingFallbackVersion += $LatestVersionMap[$key]
+                }
+            }
+            if ($MatchingFallbackVersion)
+            {
+                $global:FallbackId = $MatchingFallbackId[-1]
+                $FallbackVersion = $MatchingFallbackVersion[-1]
+                Write-Host "Return fallback version: $FallbackVersion (from $($MatchingFallbackId[-1]))"
+                return $FallbackVersion
+            }
         }
     }
 
@@ -192,6 +200,40 @@ function Remove-Pack([string]$Id, [string]$Version, [string]$Kind) {
     }
 }
 
+# BEGIN VERSION BAND DETECTION -- covered by scripts/test-version-band.sh
+# Map a full .NET SDK version to the SDK feature band used for the workload manifest
+# directory / NuGet package suffix. Must stay behaviourally identical to
+# compute_target_version_band() in workload-install.sh.
+function Get-TargetVersionBand([string]$DotnetVersion)
+{
+    $VersionSplitSymbol = '.'
+    $SplitVersion = $DotnetVersion.Split($VersionSplitSymbol)
+    $CurrentDotnetVersion = [Version]"$($SplitVersion[0]).$($SplitVersion[1])"
+    # Feature bands round the patch component down to the nearest hundred: 10.0.404 -> 10.0.400.
+    $DotnetVersionBand = $SplitVersion[0] + $VersionSplitSymbol + $SplitVersion[1] + $VersionSplitSymbol + $SplitVersion[2][0] + "00"
+
+    if ($CurrentDotnetVersion -ge [Version]"7.0")
+    {
+        $IsPreviewVersion = $DotnetVersion.Contains("-preview") -or $DotnetVersion.Contains("-rc") -or $DotnetVersion.Contains("-alpha")
+        if ($IsPreviewVersion -and ($SplitVersion.Count -ge 4)) {
+            return $DotnetVersionBand + $SplitVersion[2].SubString(3) + $VersionSplitSymbol + $($SplitVersion[3])
+        }
+        elseif ($DotnetVersion.Contains("-rtm") -and ($SplitVersion.Count -ge 3)) {
+            return $DotnetVersionBand + $SplitVersion[2].SubString(3)
+        }
+    }
+    return $DotnetVersionBand
+}
+
+# '<base>-11.0.100-preview.7' -> '<base>-11.0.' so fallback stays inside one .NET major.minor.
+function Get-BandFamilyPrefix([string]$ManifestId)
+{
+    $Match = [regex]::Match($ManifestId, '-(\d+\.\d+)\.')
+    if (-not $Match.Success) { return "" }
+    return $ManifestId.Substring(0, $ManifestId.IndexOf("-") + 1) + $Match.Groups[1].Value + "."
+}
+# END VERSION BAND DETECTION
+
 function Install-TizenWorkload([string]$DotnetVersion)
 {
     $VersionSplitSymbol = '.'
@@ -202,24 +244,8 @@ function Install-TizenWorkload([string]$DotnetVersion)
     $ManifestName = "$ManifestBaseName-$DotnetVersionBand"
 
     if ($DotnetTargetVersionBand -eq "<auto>" -or $UpdateAllWorkloads.IsPresent) {
-        if ($CurrentDotnetVersion -ge "7.0")
-        {
-            $IsPreviewVersion = $DotnetVersion.Contains("-preview") -or $DotnetVersion.Contains("-rc") -or $DotnetVersion.Contains("-alpha")
-            if ($IsPreviewVersion -and ($SplitVersion.Count -ge 4)) {
-                $DotnetTargetVersionBand = $DotnetVersionBand + $SplitVersion[2].SubString(3) + $VersionSplitSymbol + $($SplitVersion[3])
-                $ManifestName = "$ManifestBaseName-$DotnetTargetVersionBand"
-            }
-            elseif ($DotnetVersion.Contains("-rtm") -and ($SplitVersion.Count -ge 3)) {
-                $DotnetTargetVersionBand = $DotnetVersionBand + $SplitVersion[2].SubString(3)
-                $ManifestName = "$ManifestBaseName-$DotnetTargetVersionBand"
-            }
-            else {
-                $DotnetTargetVersionBand = $DotnetVersionBand
-            }
-        }
-        else {
-            $DotnetTargetVersionBand = $DotnetVersionBand
-        }
+        $DotnetTargetVersionBand = Get-TargetVersionBand -DotnetVersion $DotnetVersion
+        $ManifestName = "$ManifestBaseName-$DotnetTargetVersionBand"
     }
 
     # Check latest version of manifest.
@@ -295,7 +321,8 @@ if ($DotnetInstallDir -eq "<auto>") {
     }
 }
 if (-Not $(Test-Path "$DotnetInstallDir")) {
-    Write-Error "No installed dotnet '$DotnetInstallDir'."
+    Write-Host "No installed dotnet '$DotnetInstallDir'."
+    exit 1
 }
 
 # Check installed dotnet version
@@ -313,27 +340,38 @@ if (Get-Command $DotnetCommand -ErrorAction SilentlyContinue)
 }
 else
 {
-    Write-Error "'$DotnetCommand' occurs an error."
+    Write-Host "'$DotnetCommand' occurs an error."
+    exit 1
 }
 
 if (-Not $InstalledDotnetSdks)
 {
     Write-Host "`n.NET SDK version 6 or later is required to install Tizen Workload."
+    exit 1
 }
-else
+
+# Track per-SDK failures. -UpdateAllWorkloads keeps going across the remaining SDKs,
+# but the overall run must still report failure to the caller.
+$FailedSdks = @()
+
+foreach ($DotnetSdk in $InstalledDotnetSdks)
 {
-    foreach ($DotnetSdk in $InstalledDotnetSdks)
-    {
-        try {
-            Write-Host "`nCheck Tizen Workload for sdk $DotnetSdk"
-            Install-TizenWorkload -DotnetVersion $DotnetSdk
-        }
-        catch {
-            Write-Host "Failed to install Tizen Workload for sdk $DotnetSdk"
-            Write-Host "$_"
-            Continue
-        }
+    try {
+        Write-Host "`nCheck Tizen Workload for sdk $DotnetSdk"
+        Install-TizenWorkload -DotnetVersion $DotnetSdk
     }
+    catch {
+        Write-Host "Failed to install Tizen Workload for sdk $DotnetSdk"
+        Write-Host "$_"
+        $FailedSdks += $DotnetSdk
+        Continue
+    }
+}
+
+if ($FailedSdks.Count -gt 0)
+{
+    Write-Host "`nFAILED to install Tizen workload for sdk(s): $($FailedSdks -join ', ')"
+    exit 1
 }
 
 Write-Host "`nDone"

--- a/workload/scripts/workload-install.ps1
+++ b/workload/scripts/workload-install.ps1
@@ -280,6 +280,19 @@ function Install-TizenWorkload([string]$DotnetVersion)
         $Version      = $ResolvedVersion
     }
 
+    # Unconditional gate, regardless of which branch above set $Version.
+    #
+    # An explicit -Version "" (or whitespace) does not equal "<latest>", so it skips the
+    # resolution block entirely and would otherwise reach the manifest REMOVAL below and a
+    # versionless NuGet URL - and the v2 package endpoint serves the LATEST package when the
+    # URL carries no version segment. Reject before any removal, URL construction or download.
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        throw "A manifest version is required. Pass -Version <VERSION>, or '<latest>' to resolve it automatically."
+    }
+    if ([string]::IsNullOrWhiteSpace($ManifestName)) {
+        throw "Could not determine the manifest package id for $DotnetVersion."
+    }
+
     # Check workload manifest directory.
     $ManifestDir = Join-Path -Path $DotnetInstallDir -ChildPath "sdk-manifests" | Join-Path -ChildPath $DotnetTargetVersionBand
     $TizenManifestDir = Join-Path -Path $ManifestDir -ChildPath "samsung.net.sdk.tizen"

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -161,12 +161,29 @@ function getLatestVersion () {
         return
     fi
     local prefix="${manifestId%%-*}-${family}."
+    local requestedBand="${manifestId#*-}"
+    local requestedKey; requestedKey="$(band_sort_key "$requestedBand")"
+
+    # Choose the CLOSEST band that is <= the requested one. Taking the last/highest match
+    # meant a request for 10.0.200 resolved to 10.0.300 - a NEWER band, whose manifest may
+    # not be valid for the requested SDK - while skipping a perfectly good 10.0.200 or
+    # 10.0.100. Bands are ordered by a numeric key so map order is irrelevant.
     local fallbackId=""
     local fallbackVersion=""
+    local bestKey=""
     for entry in "${LatestVersionMap[@]}"; do
         mapKey="${entry%%=*}"
         mapValue="${entry#*=}"
-        if [[ "$mapKey" == "$prefix"* ]]; then
+        case "$mapKey" in
+            "$prefix"*) ;;
+            *) continue ;;
+        esac
+        local candidateBand="${mapKey#*-}"
+        local candidateKey; candidateKey="$(band_sort_key "$candidateBand")"
+        # Skip anything newer than what was asked for.
+        [[ "$candidateKey" > "$requestedKey" ]] && continue
+        if [[ -z "$bestKey" || "$candidateKey" > "$bestKey" ]]; then
+            bestKey="$candidateKey"
             fallbackId="$mapKey"
             fallbackVersion="$mapValue"
         fi
@@ -212,6 +229,25 @@ function compute_target_version_band() {
     fi
     echo "$band"
 }
+# Comparable sort key for an SDK feature band, e.g. '10.0.300' or '11.0.100-preview.7'.
+# Zero-padded so plain string comparison orders bands correctly, with pre-release bands
+# sorting BEFORE the corresponding stable band ('0' < '1').
+band_sort_key() {
+    local band="$1"
+    local core="${band%%-*}"
+    local pre=""
+    [[ "$band" == *-* ]] && pre="${band#*-}"
+    local IFS='.'
+    local -a parts
+    read -r -a parts <<< "$core"
+    local major="${parts[0]:-0}" minor="${parts[1]:-0}" patch="${parts[2]:-0}"
+    if [[ -n "$pre" ]]; then
+        printf '%05d%05d%05d0%s\n' "$major" "$minor" "$patch" "$pre"
+    else
+        printf '%05d%05d%05d1\n' "$major" "$minor" "$patch"
+    fi
+}
+
 # END VERSION BAND DETECTION
 
 function install_tizenworkload() {
@@ -226,10 +262,18 @@ function install_tizenworkload() {
         MANIFEST_VERSION="<latest>"
     fi
 
-    # Check version band
+    # Check version band.
+    #
+    # -t/--dotnet-target-version-band deliberately installs into a DIFFERENT band than the
+    # running SDK (documented: verifying a workload against the next band). Remember which
+    # case applies so the post-pin equality check below is applied only when the band was
+    # derived automatically.
+    TARGET_BAND_IS_EXPLICIT="false"
     if [[ "$DOTNET_TARGET_VERSION_BAND" == "<auto>" ]]; then
         DOTNET_TARGET_VERSION_BAND=$(compute_target_version_band "$DOTNET_VERSION")
         MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_TARGET_VERSION_BAND"
+    else
+        TARGET_BAND_IS_EXPLICIT="true"
     fi
 
     # Check latest version of manifest.
@@ -262,6 +306,50 @@ function install_tizenworkload() {
         return 1
     fi
 
+    # Pin and validate the SDK BEFORE touching anything on disk.
+    #
+    # This used to run after the manifest had already been copied, so a pin failure left a
+    # replaced manifest behind. All validation now happens before the first mutation.
+    if [ -f global.json ]; then
+        CACHE_GLOBAL_JSON="true"
+        mv global.json global.json.bak
+    else
+        CACHE_GLOBAL_JSON="false"
+    fi
+
+    restore_global_json() {
+        rm -f global.json
+        if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
+    }
+
+    # This function is invoked under `if !`, which disables errexit for everything it calls,
+    # so every command here is checked explicitly.
+    if ! "$DOTNET_INSTALL_DIR/dotnet" new globaljson --sdk-version "$DOTNET_VERSION" --force >/dev/null; then
+        echo "Failed to pin SDK $DOTNET_VERSION via global.json."
+        restore_global_json
+        return 1
+    fi
+
+    EFFECTIVE_VERSION="$("$DOTNET_INSTALL_DIR/dotnet" --version 2>/dev/null)"
+    if [ "$EFFECTIVE_VERSION" != "$DOTNET_VERSION" ]; then
+        echo "SDK pin did not take effect: requested $DOTNET_VERSION, active ${EFFECTIVE_VERSION:-<unknown>}."
+        restore_global_json
+        return 1
+    fi
+
+    # The active SDK must match the destination band ONLY when that band was derived from
+    # the SDK. An explicit -t is a deliberate cross-band install.
+    if [[ "$TARGET_BAND_IS_EXPLICIT" != "true" ]]; then
+        EFFECTIVE_BAND="$(compute_target_version_band "$EFFECTIVE_VERSION")"
+        if [ "$EFFECTIVE_BAND" != "$DOTNET_TARGET_VERSION_BAND" ]; then
+            echo "Band mismatch: manifest targets $DOTNET_TARGET_VERSION_BAND but the active SDK resolves to $EFFECTIVE_BAND."
+            restore_global_json
+            return 1
+        fi
+    else
+        echo "Installing into explicitly requested band $DOTNET_TARGET_VERSION_BAND (active SDK $EFFECTIVE_VERSION)."
+    fi
+
     # Check workload manifest directory.
     SDK_MANIFESTS_DIR="$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_TARGET_VERSION_BAND"
     ensure_directory "$SDK_MANIFESTS_DIR"
@@ -287,60 +375,62 @@ function install_tizenworkload() {
     fi
     chmod 744 "$TMPDIR"/unzipped/data/*
 
-    # Copy manifest files to dotnet sdk.
-    mkdir -p "$SDK_MANIFESTS_DIR/samsung.net.sdk.tizen"
-    cp -f "$TMPDIR"/unzipped/data/* "$SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/"
-
-    if [ ! -f "$SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/WorkloadManifest.json" ]; then
-        echo "Installation is failed."
-        rm -fr $TMPDIR
+    # Verify the STAGED payload before replacing anything. Checking the destination instead
+    # meant a leftover manifest from a previous install could satisfy the check even when
+    # this download had produced nothing usable.
+    if [ ! -f "$TMPDIR/unzipped/data/WorkloadManifest.json" ]; then
+        echo "Downloaded package does not contain WorkloadManifest.json."
+        rm -fr "$TMPDIR"
+        restore_global_json
         return 1
     fi
 
-    # Install workload packs.
-    if [ -f global.json ]; then
-        CACHE_GLOBAL_JSON="true"
-        mv global.json global.json.bak
-    else
-        CACHE_GLOBAL_JSON="false"
+    # Replace the destination atomically: build the new directory alongside the old one,
+    # swap, and roll the previous contents back if any step fails. An interrupted in-place
+    # copy previously left a half-replaced manifest directory.
+    MANIFEST_DEST="$SDK_MANIFESTS_DIR/samsung.net.sdk.tizen"
+    MANIFEST_NEW="$SDK_MANIFESTS_DIR/.samsung.net.sdk.tizen.new.$$"
+    MANIFEST_OLD="$SDK_MANIFESTS_DIR/.samsung.net.sdk.tizen.old.$$"
+    rm -fr "$MANIFEST_NEW" "$MANIFEST_OLD"
+
+    if ! mkdir -p "$MANIFEST_NEW" || ! cp -f "$TMPDIR"/unzipped/data/* "$MANIFEST_NEW/"; then
+        echo "Failed to stage manifest files."
+        rm -fr "$MANIFEST_NEW" "$TMPDIR"
+        restore_global_json
+        return 1
     fi
-    # Pin the SDK for the install. Use the dotnet under test - not whatever 'dotnet' the
-    # PATH resolves to - and CHECK the result: this function is invoked under `if !`, which
-    # disables errexit for everything it calls, so an unchecked failure here would leave the
-    # workload to be installed against the wrong SDK.
-    if ! "$DOTNET_INSTALL_DIR/dotnet" new globaljson --sdk-version "$DOTNET_VERSION" --force; then
-        echo "Failed to pin SDK $DOTNET_VERSION via global.json."
-        rm -f global.json
-        if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
+    if [ ! -f "$MANIFEST_NEW/WorkloadManifest.json" ]; then
+        echo "Staged manifest is incomplete."
+        rm -fr "$MANIFEST_NEW" "$TMPDIR"
+        restore_global_json
         return 1
     fi
 
-    # Verify the pin actually took effect before installing anything.
-    EFFECTIVE_VERSION="$("$DOTNET_INSTALL_DIR/dotnet" --version 2>/dev/null)"
-    if [ "$EFFECTIVE_VERSION" != "$DOTNET_VERSION" ]; then
-        echo "SDK pin did not take effect: requested $DOTNET_VERSION, active ${EFFECTIVE_VERSION:-<unknown>}."
-        rm -f global.json
-        if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
-        return 1
+    HAD_PREVIOUS="false"
+    if [ -d "$MANIFEST_DEST" ]; then
+        if ! mv "$MANIFEST_DEST" "$MANIFEST_OLD"; then
+            echo "Failed to set aside the existing manifest."
+            rm -fr "$MANIFEST_NEW" "$TMPDIR"
+            restore_global_json
+            return 1
+        fi
+        HAD_PREVIOUS="true"
     fi
 
-    EFFECTIVE_BAND="$(compute_target_version_band "$EFFECTIVE_VERSION")"
-    if [ "$EFFECTIVE_BAND" != "$DOTNET_TARGET_VERSION_BAND" ]; then
-        echo "Band mismatch: manifest installed for $DOTNET_TARGET_VERSION_BAND but the active SDK resolves to $EFFECTIVE_BAND."
-        rm -f global.json
-        if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
+    if ! mv "$MANIFEST_NEW" "$MANIFEST_DEST"; then
+        echo "Failed to install the new manifest; rolling back."
+        if [[ "$HAD_PREVIOUS" == "true" ]]; then mv "$MANIFEST_OLD" "$MANIFEST_DEST"; fi
+        rm -fr "$MANIFEST_NEW" "$TMPDIR"
+        restore_global_json
         return 1
     fi
-
+    rm -fr "$MANIFEST_OLD"
     "$DOTNET_INSTALL_DIR/dotnet" workload install tizen --skip-manifest-update
     local install_status=$?
 
     # Clean-up
     rm -fr "$TMPDIR"
-    rm -f global.json
-    if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then
-        mv global.json.bak global.json
-    fi
+    restore_global_json
 
     if [ $install_status -ne 0 ]; then
         echo "Failed to install Tizen workload packs for $DOTNET_VERSION (exit $install_status)."

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -1,9 +1,8 @@
+#!/bin/bash -e
 #
 # Copyright (c) Samsung Electronics. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
-
-#!/bin/bash -e
 
 MANIFEST_BASE_NAME="samsung.net.sdk.tizen.manifest"
 MANIFEST_VERSION="<latest>"
@@ -143,9 +142,17 @@ function getLatestVersion () {
              return
          fi
     done
-    # return fallback version
+    # Return a fallback version, but only from the SAME .NET major.minor family.
+    # '<base>-11.0.100-preview.7' -> '<base>-11.0.' so an 11.x request can never
+    # resolve to a 10.x manifest. Must match Get-BandFamilyPrefix in workload-install.ps1.
     local manifestId="$1"
-    local prefix="${manifestId%.*}"
+    local family="${manifestId#*-}"
+    family="$(echo "$family" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')"
+    if [[ ! "$family" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        echo ""
+        return
+    fi
+    local prefix="${manifestId%%-*}-${family}."
     local fallbackVersion=""
     for entry in "${LatestVersionMap[@]}"; do
         mapKey="${entry%%=*}"
@@ -220,7 +227,7 @@ function install_tizenworkload() {
                 echo "Return cached latest version: $MANIFEST_VERSION"
             else
                 echo "Failed to get the latest version of $MANIFEST_NAME."
-                return
+                return 1
             fi
         fi
     fi
@@ -239,7 +246,8 @@ function install_tizenworkload() {
     unzip -qq -d $TMPDIR/unzipped $TMPDIR/manifest.zip
     if [ ! -d $TMPDIR/unzipped/data ]; then
         echo "No such files to install."
-        return
+        rm -fr $TMPDIR
+        return 1
     fi
     chmod 744 $TMPDIR/unzipped/data/*
 
@@ -249,7 +257,8 @@ function install_tizenworkload() {
 
     if [ ! -f $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/WorkloadManifest.json ]; then
         echo "Installation is failed."
-        return
+        rm -fr $TMPDIR
+        return 1
     fi
 
     # Install workload packs.
@@ -261,12 +270,18 @@ function install_tizenworkload() {
     fi
     dotnet new globaljson --sdk-version $DOTNET_VERSION
     $DOTNET_INSTALL_DIR/dotnet workload install tizen --skip-manifest-update
+    local install_status=$?
 
     # Clean-up
     rm -fr $TMPDIR
     rm global.json
     if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then
         mv global.json.bak global.json
+    fi
+
+    if [ $install_status -ne 0 ]; then
+        echo "Failed to install Tizen workload packs for $DOTNET_VERSION (exit $install_status)."
+        return $install_status
     fi
 
     echo "Done installing Tizen workload $MANIFEST_VERSION"
@@ -279,13 +294,23 @@ else
     INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --version)
 fi
 
+FAILED_SDKS=""
+
 if [ -z "$INSTALLED_DOTNET_SDKS" ]; then
     echo ".NET SDK version 6 or later is required to install Tizen Workload."
-else
-    for DOTNET_SDK in $INSTALLED_DOTNET_SDKS; do
-        echo "Check Tizen Workload for sdk $DOTNET_SDK."
-        install_tizenworkload $DOTNET_SDK
-    done
+    exit 1
+fi
+
+for DOTNET_SDK in $INSTALLED_DOTNET_SDKS; do
+    echo "Check Tizen Workload for sdk $DOTNET_SDK."
+    if ! install_tizenworkload $DOTNET_SDK; then
+        FAILED_SDKS="$FAILED_SDKS $DOTNET_SDK"
+    fi
+done
+
+if [ -n "$FAILED_SDKS" ]; then
+    echo "FAILED to install Tizen workload for sdk(s):$FAILED_SDKS"
+    exit 1
 fi
 
 echo "DONE"

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -143,6 +143,9 @@ fi
 # that version under the originally requested (non-existent) id 404s. For example
 # a request for '...manifest-10.0.400' resolves to '...manifest-10.0.300=10.0.127'
 # and the 10.0.300 package is what has to be downloaded.
+# BEGIN FALLBACK RESOLVER -- extracted by scripts/test-version-band.sh so the tests
+# exercise the SHIPPED resolver. A hand-copied reimplementation in the test cannot
+# detect drift from this function, which is the entire point of testing it.
 function getLatestVersion () {
     for index in "${LatestVersionMap[@]}"; do
          if [ "${index%%=*}" = "${1}" ]; then
@@ -194,6 +197,7 @@ function getLatestVersion () {
     fi
     echo "$fallbackId=$fallbackVersion"
 }
+# END FALLBACK RESOLVER
 
 # Check installed dotnet version
 DOTNET_COMMAND="$DOTNET_INSTALL_DIR/dotnet"
@@ -242,8 +246,27 @@ band_sort_key() {
     read -r -a parts <<< "$core"
     local major="${parts[0]:-0}" minor="${parts[1]:-0}" patch="${parts[2]:-0}"
     if [[ -n "$pre" ]]; then
-        printf '%05d%05d%05d0%s\n' "$major" "$minor" "$patch" "$pre"
+        # Normalise the pre-release so a plain string comparison follows SemVer precedence.
+        # Appending it raw made the comparison lexicographic, where "preview.10" sorts
+        # BELOW "preview.9" because '1' < '9' - so a request against a preview.10 band
+        # silently fell back to preview.9. Numeric identifiers are therefore zero-padded
+        # and tagged 0, alphanumeric ones tagged 1 (numeric < alphanumeric in SemVer).
+        # '.' sorts below digits and letters, so a shorter identifier list sorts first,
+        # which is also what SemVer requires.
+        local normalised=""
+        local ident
+        local oldIFS="$IFS"
+        IFS='.'
+        for ident in $pre; do
+            case "$ident" in
+                ''|*[!0-9]*) normalised="$normalised.$(printf '1%s' "$ident")" ;;
+                *)           normalised="$normalised.$(printf '0%010d' "$ident")" ;;
+            esac
+        done
+        IFS="$oldIFS"
+        printf '%05d%05d%05d0%s\n' "$major" "$minor" "$patch" "$normalised"
     else
+        # No pre-release: sorts above every pre-release of the same core version.
         printf '%05d%05d%05d1\n' "$major" "$minor" "$patch"
     fi
 }
@@ -271,10 +294,15 @@ function install_tizenworkload() {
     TARGET_BAND_IS_EXPLICIT="false"
     if [[ "$DOTNET_TARGET_VERSION_BAND" == "<auto>" ]]; then
         DOTNET_TARGET_VERSION_BAND=$(compute_target_version_band "$DOTNET_VERSION")
-        MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_TARGET_VERSION_BAND"
     else
         TARGET_BAND_IS_EXPLICIT="true"
     fi
+    # The manifest package is named after the band it is FOR, so it must always follow the
+    # target band - including when that band was requested explicitly. Leaving it derived
+    # from the running SDK meant `-t 10.0.200` on a 10.0.100 SDK downloaded
+    # samsung.net.sdk.tizen.manifest-10.0.100 and installed it into sdk-manifests/10.0.200:
+    # the wrong band's manifest, in the right band's directory, reported as success.
+    MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_TARGET_VERSION_BAND"
 
     # Check latest version of manifest.
     if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then
@@ -320,20 +348,52 @@ function install_tizenworkload() {
     restore_global_json() {
         rm -f global.json
         if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
+        CACHE_GLOBAL_JSON="false"
     }
+
+    # Everything from here to the end of the install is ONE transaction. A partial install
+    # is worse than no install: the SDK would be left with a manifest describing packs that
+    # are not present, or - when a download failed - with global.json still pinned and the
+    # user's real global.json sitting in global.json.bak, which the next loop iteration
+    # would then overwrite and destroy.
+    TX_TMPDIR=""
+    TX_MANIFEST_DEST=""
+    TX_MANIFEST_NEW=""
+    TX_MANIFEST_OLD=""
+    TX_SWAPPED="false"
+    TX_HAD_PREVIOUS="false"
+
+    # Release temporary state. Used on both paths; on the failure path TX_SWAPPED is still
+    # true, so the previous manifest is put back first.
+    tx_finish() {
+        if [[ "$TX_SWAPPED" == "true" ]]; then
+            # Put the previous manifest back exactly as it was.
+            rm -fr "$TX_MANIFEST_DEST"
+            if [[ "$TX_HAD_PREVIOUS" == "true" ]] && [ -d "$TX_MANIFEST_OLD" ]; then
+                mv "$TX_MANIFEST_OLD" "$TX_MANIFEST_DEST"
+            fi
+        fi
+        [ -n "$TX_MANIFEST_NEW" ] && rm -fr "$TX_MANIFEST_NEW"
+        [ -n "$TX_MANIFEST_OLD" ] && rm -fr "$TX_MANIFEST_OLD"
+        [ -n "$TX_TMPDIR" ] && rm -fr "$TX_TMPDIR"
+        restore_global_json
+    }
+
+    # Roll the SDK back to exactly the state it was in before this function ran.
+    tx_rollback() { tx_finish; }
 
     # This function is invoked under `if !`, which disables errexit for everything it calls,
     # so every command here is checked explicitly.
     if ! "$DOTNET_INSTALL_DIR/dotnet" new globaljson --sdk-version "$DOTNET_VERSION" --force >/dev/null; then
         echo "Failed to pin SDK $DOTNET_VERSION via global.json."
-        restore_global_json
+        tx_rollback
         return 1
     fi
 
     EFFECTIVE_VERSION="$("$DOTNET_INSTALL_DIR/dotnet" --version 2>/dev/null)"
     if [ "$EFFECTIVE_VERSION" != "$DOTNET_VERSION" ]; then
         echo "SDK pin did not take effect: requested $DOTNET_VERSION, active ${EFFECTIVE_VERSION:-<unknown>}."
-        restore_global_json
+        tx_rollback
         return 1
     fi
 
@@ -343,7 +403,7 @@ function install_tizenworkload() {
         EFFECTIVE_BAND="$(compute_target_version_band "$EFFECTIVE_VERSION")"
         if [ "$EFFECTIVE_BAND" != "$DOTNET_TARGET_VERSION_BAND" ]; then
             echo "Band mismatch: manifest targets $DOTNET_TARGET_VERSION_BAND but the active SDK resolves to $EFFECTIVE_BAND."
-            restore_global_json
+            tx_rollback
             return 1
         fi
     else
@@ -355,6 +415,7 @@ function install_tizenworkload() {
     ensure_directory "$SDK_MANIFESTS_DIR"
 
     TMPDIR=$(mktemp -d)
+    TX_TMPDIR="$TMPDIR"
 
     echo "Installing $MANIFEST_NAME/$MANIFEST_VERSION to $SDK_MANIFESTS_DIR..."
 
@@ -363,14 +424,18 @@ function install_tizenworkload() {
     CURL_STATUS=$?
     if [ $CURL_STATUS -ne 0 ]; then
         echo "Failed to download $MANIFEST_NAME/$MANIFEST_VERSION (curl exit $CURL_STATUS)."
-        rm -fr "$TMPDIR"
+        tx_rollback
         return 1
     fi
 
-    unzip -qq -d "$TMPDIR/unzipped" "$TMPDIR/manifest.zip"
+    if ! unzip -qq -d "$TMPDIR/unzipped" "$TMPDIR/manifest.zip"; then
+        echo "Failed to extract $MANIFEST_NAME/$MANIFEST_VERSION."
+        tx_rollback
+        return 1
+    fi
     if [ ! -d "$TMPDIR/unzipped/data" ]; then
         echo "No such files to install."
-        rm -fr "$TMPDIR"
+        tx_rollback
         return 1
     fi
     chmod 744 "$TMPDIR"/unzipped/data/*
@@ -380,8 +445,7 @@ function install_tizenworkload() {
     # this download had produced nothing usable.
     if [ ! -f "$TMPDIR/unzipped/data/WorkloadManifest.json" ]; then
         echo "Downloaded package does not contain WorkloadManifest.json."
-        rm -fr "$TMPDIR"
-        restore_global_json
+        tx_rollback
         return 1
     fi
 
@@ -392,17 +456,18 @@ function install_tizenworkload() {
     MANIFEST_NEW="$SDK_MANIFESTS_DIR/.samsung.net.sdk.tizen.new.$$"
     MANIFEST_OLD="$SDK_MANIFESTS_DIR/.samsung.net.sdk.tizen.old.$$"
     rm -fr "$MANIFEST_NEW" "$MANIFEST_OLD"
+    TX_MANIFEST_DEST="$MANIFEST_DEST"
+    TX_MANIFEST_NEW="$MANIFEST_NEW"
+    TX_MANIFEST_OLD="$MANIFEST_OLD"
 
     if ! mkdir -p "$MANIFEST_NEW" || ! cp -f "$TMPDIR"/unzipped/data/* "$MANIFEST_NEW/"; then
         echo "Failed to stage manifest files."
-        rm -fr "$MANIFEST_NEW" "$TMPDIR"
-        restore_global_json
+        tx_rollback
         return 1
     fi
     if [ ! -f "$MANIFEST_NEW/WorkloadManifest.json" ]; then
         echo "Staged manifest is incomplete."
-        rm -fr "$MANIFEST_NEW" "$TMPDIR"
-        restore_global_json
+        tx_rollback
         return 1
     fi
 
@@ -410,32 +475,36 @@ function install_tizenworkload() {
     if [ -d "$MANIFEST_DEST" ]; then
         if ! mv "$MANIFEST_DEST" "$MANIFEST_OLD"; then
             echo "Failed to set aside the existing manifest."
-            rm -fr "$MANIFEST_NEW" "$TMPDIR"
-            restore_global_json
+            tx_rollback
             return 1
         fi
         HAD_PREVIOUS="true"
+        TX_HAD_PREVIOUS="true"
     fi
 
     if ! mv "$MANIFEST_NEW" "$MANIFEST_DEST"; then
         echo "Failed to install the new manifest; rolling back."
-        if [[ "$HAD_PREVIOUS" == "true" ]]; then mv "$MANIFEST_OLD" "$MANIFEST_DEST"; fi
-        rm -fr "$MANIFEST_NEW" "$TMPDIR"
-        restore_global_json
+        tx_rollback
         return 1
     fi
-    rm -fr "$MANIFEST_OLD"
-    "$DOTNET_INSTALL_DIR/dotnet" workload install tizen --skip-manifest-update
-    local install_status=$?
+    TX_SWAPPED="true"
 
-    # Clean-up
-    rm -fr "$TMPDIR"
-    restore_global_json
+    # The pack install is part of the transaction. If it fails, the new manifest must not
+    # be left behind: it advertises packs that are not on disk, so every subsequent build
+    # against that band fails with a missing-pack error that looks unrelated to this run.
+    "$DOTNET_INSTALL_DIR/dotnet" workload install tizen --skip-manifest-update
+    install_status=$?
 
     if [ $install_status -ne 0 ]; then
         echo "Failed to install Tizen workload packs for $DOTNET_VERSION (exit $install_status)."
+        echo "Rolling back the manifest so the SDK is left as it was."
+        tx_rollback
         return $install_status
     fi
+
+    # Committed: keep the new manifest, drop the saved copy and the temporary state.
+    TX_SWAPPED="false"
+    tx_finish
 
     echo "Done installing Tizen workload $MANIFEST_VERSION"
     echo ""

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -165,10 +165,37 @@ if [ ! -x "$DOTNET_COMMAND" ]; then
     exit 1
 fi
 
+# BEGIN VERSION BAND DETECTION -- covered by scripts/test-version-band.sh
+# Map a full .NET SDK version to the SDK feature band used for the workload
+# manifest directory / NuGet package suffix.
+#   10.0.100                     -> 10.0.100
+#   10.0.100-rc.2.25502.107      -> 10.0.100-rc.2
+#   11.0.100-preview.7.26381.103 -> 11.0.100-preview.7
+#   8.0.100-rtm.23512.16         -> 8.0.100-rtm
+#   6.0.419                      -> 6.0.400   (pre-net7 SDKs have no preview bands)
+function compute_target_version_band() {
+    local dotnet_version="$1"
+    local -a array
+    IFS='.' read -r -a array <<< "$dotnet_version"
+    local current_major="${array[0]}"
+    local band="${array[0]}.${array[1]}.${array[2]:0:1}00"
+
+    if [[ "$current_major" -ge "7" ]]; then
+        if [[ "$dotnet_version" == *"-preview"* || "$dotnet_version" == *"-rc"* || "$dotnet_version" == *"-alpha"* ]] && [[ ${#array[@]} -ge 4 ]]; then
+            echo "$band${array[2]:3}.${array[3]}"
+            return
+        elif [[ "$dotnet_version" == *"-rtm"* ]] && [[ ${#array[@]} -ge 3 ]]; then
+            echo "$band${array[2]:3}"
+            return
+        fi
+    fi
+    echo "$band"
+}
+# END VERSION BAND DETECTION
+
 function install_tizenworkload() {
     DOTNET_VERSION=$1
     IFS='.' read -r -a array <<< "$DOTNET_VERSION"
-    CURRENT_DOTNET_VERSION=${array[0]}
     DOTNET_VERSION_BAND="${array[0]}.${array[1]}.${array[2]:0:1}00"
     MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_VERSION_BAND"
 
@@ -180,19 +207,8 @@ function install_tizenworkload() {
 
     # Check version band
     if [[ "$DOTNET_TARGET_VERSION_BAND" == "<auto>" ]]; then
-        if [[ "$CURRENT_DOTNET_VERSION" -ge "7" ]]; then
-            if [[ "$DOTNET_VERSION" == *"-preview"* || $DOTNET_VERSION == *"-rc"* || $DOTNET_VERSION == *"-alpha"* ]] && [[ ${#array[@]} -ge 4 ]]; then
-                DOTNET_TARGET_VERSION_BAND="$DOTNET_VERSION_BAND${array[2]:3}.${array[3]}"
-                MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_TARGET_VERSION_BAND"
-            elif [[ "$DOTNET_VERSION" == *"-rtm"* ]] && [[ ${#array[@]} -ge 3 ]]; then
-                DOTNET_TARGET_VERSION_BAND="$DOTNET_VERSION_BAND${array[2]:3}"
-                MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_TARGET_VERSION_BAND"
-            else
-                DOTNET_TARGET_VERSION_BAND=$DOTNET_VERSION_BAND
-            fi
-        else
-            DOTNET_TARGET_VERSION_BAND=$DOTNET_VERSION_BAND
-        fi
+        DOTNET_TARGET_VERSION_BAND=$(compute_target_version_band "$DOTNET_VERSION")
+        MANIFEST_NAME="$MANIFEST_BASE_NAME-$DOTNET_TARGET_VERSION_BAND"
     fi
 
     # Check latest version of manifest.
@@ -258,7 +274,7 @@ function install_tizenworkload() {
 }
 
 if [[ "$UPDATE_ALL_WORKLOADS" == "true" ]]; then
-    INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --list-sdks | sed -n '/^6\|^7/p' | sed 's/ \[.*//g')
+    INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --list-sdks | sed -E -n '/^([6-9]|[1-9][0-9]+)\./p' | sed 's/ \[.*//g')
 else
     INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --version)
 fi
@@ -266,4 +282,10 @@ fi
 if [ -z "$INSTALLED_DOTNET_SDKS" ]; then
     echo ".NET SDK version 6 or later is required to install Tizen Workload."
 else
-    for DOTNET_SDK in $INSTALLED_DOTNET_SD                                                                                                                                      
+    for DOTNET_SDK in $INSTALLED_DOTNET_SDKS; do
+        echo "Check Tizen Workload for sdk $DOTNET_SDK."
+        install_tizenworkload $DOTNET_SDK
+    done
+fi
+
+echo "DONE"

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -257,6 +257,11 @@ function install_tizenworkload() {
         fi
     fi
 
+    if [ -z "$MANIFEST_VERSION" ] || [ -z "$MANIFEST_NAME" ]; then
+        echo "Refusing to install: resolved an empty manifest id/version for $DOTNET_VERSION."
+        return 1
+    fi
+
     # Check workload manifest directory.
     SDK_MANIFESTS_DIR="$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_TARGET_VERSION_BAND"
     ensure_directory "$SDK_MANIFESTS_DIR"
@@ -299,13 +304,40 @@ function install_tizenworkload() {
     else
         CACHE_GLOBAL_JSON="false"
     fi
-    dotnet new globaljson --sdk-version $DOTNET_VERSION
+    # Pin the SDK for the install. Use the dotnet under test - not whatever 'dotnet' the
+    # PATH resolves to - and CHECK the result: this function is invoked under `if !`, which
+    # disables errexit for everything it calls, so an unchecked failure here would leave the
+    # workload to be installed against the wrong SDK.
+    if ! "$DOTNET_INSTALL_DIR/dotnet" new globaljson --sdk-version "$DOTNET_VERSION" --force; then
+        echo "Failed to pin SDK $DOTNET_VERSION via global.json."
+        rm -f global.json
+        if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
+        return 1
+    fi
+
+    # Verify the pin actually took effect before installing anything.
+    EFFECTIVE_VERSION="$("$DOTNET_INSTALL_DIR/dotnet" --version 2>/dev/null)"
+    if [ "$EFFECTIVE_VERSION" != "$DOTNET_VERSION" ]; then
+        echo "SDK pin did not take effect: requested $DOTNET_VERSION, active ${EFFECTIVE_VERSION:-<unknown>}."
+        rm -f global.json
+        if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
+        return 1
+    fi
+
+    EFFECTIVE_BAND="$(compute_target_version_band "$EFFECTIVE_VERSION")"
+    if [ "$EFFECTIVE_BAND" != "$DOTNET_TARGET_VERSION_BAND" ]; then
+        echo "Band mismatch: manifest installed for $DOTNET_TARGET_VERSION_BAND but the active SDK resolves to $EFFECTIVE_BAND."
+        rm -f global.json
+        if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then mv global.json.bak global.json; fi
+        return 1
+    fi
+
     "$DOTNET_INSTALL_DIR/dotnet" workload install tizen --skip-manifest-update
     local install_status=$?
 
     # Clean-up
     rm -fr "$TMPDIR"
-    rm global.json
+    rm -f global.json
     if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then
         mv global.json.bak global.json
     fi

--- a/workload/scripts/workload-install.sh
+++ b/workload/scripts/workload-install.sh
@@ -63,7 +63,7 @@ while [ $# -ne 0 ]; do
             ;;
         -d|--dotnet-install-dir)
             shift
-            DOTNET_INSTALL_DIR=$1
+            DOTNET_INSTALL_DIR="$1"
             ;;
         -t|--dotnet-target-version-band)
             shift
@@ -95,7 +95,7 @@ while [ $# -ne 0 ]; do
 done
 
 function read_dotnet_link() {
-    cd -P "$(dirname "$1")"
+    cd -P "$(dirname "$1")" || return 1
     dotnet_file="$PWD/$(basename "$1")"
     while [[ -h "$dotnet_file" ]]; do
         cd -P "$(dirname "$dotnet_file")"
@@ -112,33 +112,41 @@ function error_permission_denied() {
 }
 
 function ensure_directory() {
-    if [ ! -d $1 ]; then
-        mkdir -p $1 || error_permission_denied
+    if [ ! -d "$1" ]; then
+        mkdir -p "$1" || error_permission_denied
     fi
-    [ ! -w $1 ] && error_permission_denied
+    [ ! -w "$1" ] && error_permission_denied
 }
 
 # Check dotnet install directory.
 if [[ "$DOTNET_INSTALL_DIR" == "<auto>" ]]; then
     if [[ -n "$DOTNET_ROOT" && -d "$DOTNET_ROOT" ]]; then
-        DOTNET_INSTALL_DIR=$DOTNET_ROOT
+        DOTNET_INSTALL_DIR="$DOTNET_ROOT"
     elif [[ -d "$DOTNET_DEFAULT_PATH_LINUX" ]]; then
-        DOTNET_INSTALL_DIR=$DOTNET_DEFAULT_PATH_LINUX
+        DOTNET_INSTALL_DIR="$DOTNET_DEFAULT_PATH_LINUX"
     elif [[ -d "$DOTNET_DEFAULT_PATH_MACOS" ]]; then
-        DOTNET_INSTALL_DIR=$DOTNET_DEFAULT_PATH_MACOS
+        DOTNET_INSTALL_DIR="$DOTNET_DEFAULT_PATH_MACOS"
     elif [[ -n "$(which dotnet)" ]]; then
-        DOTNET_INSTALL_DIR=$(read_dotnet_link $(which dotnet))
+        DOTNET_INSTALL_DIR="$(read_dotnet_link "$(which dotnet)")"
     fi
 fi
-if [ ! -d $DOTNET_INSTALL_DIR ]; then
+if [ ! -d "$DOTNET_INSTALL_DIR" ]; then
     echo "No installed dotnet \`$DOTNET_INSTALL_DIR\`."
     exit 1
 fi
 
+# Resolve the manifest package to install for a requested manifest id.
+#
+# Echoes "<packageId>=<version>", or the empty string when nothing is available.
+# The package id MUST be returned alongside the version: when the requested band has
+# no published manifest we fall back to an EARLIER band's package, and downloading
+# that version under the originally requested (non-existent) id 404s. For example
+# a request for '...manifest-10.0.400' resolves to '...manifest-10.0.300=10.0.127'
+# and the 10.0.300 package is what has to be downloaded.
 function getLatestVersion () {
     for index in "${LatestVersionMap[@]}"; do
          if [ "${index%%=*}" = "${1}" ]; then
-             echo "${index#*=}"
+             echo "${1}=${index#*=}"
              return
          fi
     done
@@ -153,15 +161,21 @@ function getLatestVersion () {
         return
     fi
     local prefix="${manifestId%%-*}-${family}."
+    local fallbackId=""
     local fallbackVersion=""
     for entry in "${LatestVersionMap[@]}"; do
         mapKey="${entry%%=*}"
         mapValue="${entry#*=}"
         if [[ "$mapKey" == "$prefix"* ]]; then
+            fallbackId="$mapKey"
             fallbackVersion="$mapValue"
         fi
     done
-    echo "$fallbackVersion"
+    if [[ -z "$fallbackId" ]]; then
+        echo ""
+        return
+    fi
+    echo "$fallbackId=$fallbackVersion"
 }
 
 # Check installed dotnet version
@@ -220,11 +234,22 @@ function install_tizenworkload() {
 
     # Check latest version of manifest.
     if [[ "$MANIFEST_VERSION" == "<latest>" ]]; then
-        MANIFEST_VERSION=$(curl -s https://api.nuget.org/v3-flatcontainer/${MANIFEST_NAME,,}/index.json | grep \" | tail -n 1 | tr -d '\r' | xargs)
-        if [ -n "$MANIFEST_VERSION" ] && echo "$MANIFEST_VERSION" | grep -q "BlobNotFound"; then
-            MANIFEST_VERSION=$(getLatestVersion "$MANIFEST_NAME")
-            if [[ -n $MANIFEST_VERSION ]]; then
-                echo "Return cached latest version: $MANIFEST_VERSION"
+        # NOTE: use tr, not the ${var,,} expansion. That expansion is bash 4+, and macOS
+        # still ships bash 3.2 - where it raises "bad substitution", leaves
+        # MANIFEST_VERSION empty and silently skips the fallback below. macOS is a
+        # supported target (see DOTNET_DEFAULT_PATH_MACOS).
+        MANIFEST_NAME_LOWER=$(echo "$MANIFEST_NAME" | tr '[:upper:]' '[:lower:]')
+        MANIFEST_VERSION=$(curl -s https://api.nuget.org/v3-flatcontainer/$MANIFEST_NAME_LOWER/index.json | grep \" | tail -n 1 | tr -d '\r' | xargs)
+        # An empty response (network failure, or the package having never been published)
+        # must take the same fallback path as an explicit BlobNotFound.
+        if [ -z "$MANIFEST_VERSION" ] || echo "$MANIFEST_VERSION" | grep -q "BlobNotFound"; then
+            RESOLVED_MANIFEST=$(getLatestVersion "$MANIFEST_NAME")
+            if [[ -n $RESOLVED_MANIFEST ]]; then
+                # Download the package that actually exists. The manifest is still
+                # installed into the requested band's directory below.
+                MANIFEST_NAME="${RESOLVED_MANIFEST%%=*}"
+                MANIFEST_VERSION="${RESOLVED_MANIFEST#*=}"
+                echo "Return cached latest version: $MANIFEST_NAME/$MANIFEST_VERSION"
             else
                 echo "Failed to get the latest version of $MANIFEST_NAME."
                 return 1
@@ -233,29 +258,35 @@ function install_tizenworkload() {
     fi
 
     # Check workload manifest directory.
-    SDK_MANIFESTS_DIR=$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_TARGET_VERSION_BAND
-    ensure_directory $SDK_MANIFESTS_DIR
+    SDK_MANIFESTS_DIR="$DOTNET_INSTALL_DIR/sdk-manifests/$DOTNET_TARGET_VERSION_BAND"
+    ensure_directory "$SDK_MANIFESTS_DIR"
 
     TMPDIR=$(mktemp -d)
 
     echo "Installing $MANIFEST_NAME/$MANIFEST_VERSION to $SDK_MANIFESTS_DIR..."
 
     # Download and extract the manifest nuget package.
-    curl -s -o $TMPDIR/manifest.zip -L https://www.nuget.org/api/v2/package/$MANIFEST_NAME/$MANIFEST_VERSION
-
-    unzip -qq -d $TMPDIR/unzipped $TMPDIR/manifest.zip
-    if [ ! -d $TMPDIR/unzipped/data ]; then
-        echo "No such files to install."
-        rm -fr $TMPDIR
+    curl -sfL -o "$TMPDIR/manifest.zip" "https://www.nuget.org/api/v2/package/$MANIFEST_NAME/$MANIFEST_VERSION"
+    CURL_STATUS=$?
+    if [ $CURL_STATUS -ne 0 ]; then
+        echo "Failed to download $MANIFEST_NAME/$MANIFEST_VERSION (curl exit $CURL_STATUS)."
+        rm -fr "$TMPDIR"
         return 1
     fi
-    chmod 744 $TMPDIR/unzipped/data/*
+
+    unzip -qq -d "$TMPDIR/unzipped" "$TMPDIR/manifest.zip"
+    if [ ! -d "$TMPDIR/unzipped/data" ]; then
+        echo "No such files to install."
+        rm -fr "$TMPDIR"
+        return 1
+    fi
+    chmod 744 "$TMPDIR"/unzipped/data/*
 
     # Copy manifest files to dotnet sdk.
-    mkdir -p $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen
-    cp -f $TMPDIR/unzipped/data/* $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/
+    mkdir -p "$SDK_MANIFESTS_DIR/samsung.net.sdk.tizen"
+    cp -f "$TMPDIR"/unzipped/data/* "$SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/"
 
-    if [ ! -f $SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/WorkloadManifest.json ]; then
+    if [ ! -f "$SDK_MANIFESTS_DIR/samsung.net.sdk.tizen/WorkloadManifest.json" ]; then
         echo "Installation is failed."
         rm -fr $TMPDIR
         return 1
@@ -269,11 +300,11 @@ function install_tizenworkload() {
         CACHE_GLOBAL_JSON="false"
     fi
     dotnet new globaljson --sdk-version $DOTNET_VERSION
-    $DOTNET_INSTALL_DIR/dotnet workload install tizen --skip-manifest-update
+    "$DOTNET_INSTALL_DIR/dotnet" workload install tizen --skip-manifest-update
     local install_status=$?
 
     # Clean-up
-    rm -fr $TMPDIR
+    rm -fr "$TMPDIR"
     rm global.json
     if [[ "$CACHE_GLOBAL_JSON" == "true" ]]; then
         mv global.json.bak global.json
@@ -289,9 +320,9 @@ function install_tizenworkload() {
 }
 
 if [[ "$UPDATE_ALL_WORKLOADS" == "true" ]]; then
-    INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --list-sdks | sed -E -n '/^([6-9]|[1-9][0-9]+)\./p' | sed 's/ \[.*//g')
+    INSTALLED_DOTNET_SDKS=$("$DOTNET_COMMAND" --list-sdks | sed -E -n '/^([6-9]|[1-9][0-9]+)\./p' | sed 's/ \[.*//g')
 else
-    INSTALLED_DOTNET_SDKS=$($DOTNET_COMMAND --version)
+    INSTALLED_DOTNET_SDKS=$("$DOTNET_COMMAND" --version)
 fi
 
 FAILED_SDKS=""

--- a/workload/src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml
+++ b/workload/src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml
@@ -3,3 +3,4 @@
 <FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="8.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 8" />
 <FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="9.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 9" />
 <FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="10.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 10" />
+<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="11.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 11" />

--- a/workload/src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml
+++ b/workload/src/Samsung.NETCore.App.Runtime/data/RuntimeList.xml
@@ -1,6 +1,17 @@
-<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="6.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 6" />
-<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="7.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 7" />
-<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="8.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 8" />
-<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="9.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 9" />
-<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="10.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 10" />
-<FileList TargetFrameworkIdentifier=".NETCoreApp" TargetFrameworkVersion="11.0" FrameworkName="Microsoft.NETCore.App" Name=".NET Runtime 11" />
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Runtime pack manifest for Samsung.NETCore.App.Runtime.tizen.
+
+  This is a PLACEHOLDER runtime pack: it ships no runtime binaries (its only payload is
+  lib/net6.0-tizen/_._). Tizen applications run against the runtime provided by the device
+  platform, so there are no files to enumerate and the FileList is intentionally empty.
+
+  It must nonetheless be well-formed XML with a SINGLE root element. ResolveRuntimePackAssets
+  parses this file whenever runtime pack assets are resolved - notably for SelfContained=true -
+  and previously threw a raw XmlException because the file carried one <FileList> root per
+  .NET version, which is not valid XML.
+
+  Self-contained Tizen publishing is rejected up front with a clear TIZENSDK001 error
+  (see Samsung.Tizen.Sdk.targets) rather than silently producing an app with no runtime.
+-->
+<FileList Name=".NET Runtime - Tizen" TargetFrameworkIdentifier=".NETCoreApp" FrameworkName="Microsoft.NETCore.App" />

--- a/workload/src/Samsung.Tizen.Build.Tasks/FixupNuGetReference.cs
+++ b/workload/src/Samsung.Tizen.Build.Tasks/FixupNuGetReference.cs
@@ -32,36 +32,80 @@ namespace Samsung.Tizen.Build.Tasks
 
       var assembliesToAdd     = new Dictionary<string, string> ();
       var assembliesToRemove  = new List<ITaskItem> ();
-      var fallbackDirectories = new HashSet<string> ();
 
+      // PackageTargetFallback is an ORDERED preference list (highest/most specific first).
+      // Build a rank map so selection is by declared priority rather than by whatever order
+      // the filesystem happens to enumerate directories in.
+      var rank = new Dictionary<string, int> (StringComparer.OrdinalIgnoreCase);
+      for (int i = 0; i < PackageTargetFallback.Length; i++) {
+        var name = PackageTargetFallback [i]?.Trim ();
+        if (string.IsNullOrEmpty (name) || rank.ContainsKey (name))
+          continue;
+        rank [name] = i;
+      }
+
+      // Group the netstandard items by their containing package (the lib/ directory), so a
+      // single fallback TFM can be chosen ATOMICALLY per package. Previously every matching
+      // fallback directory was added to an unordered HashSet and assemblies were taken
+      // first-wins across all of them, which could both ignore the declared priority and mix
+      // assemblies from different TFMs within one package.
+      var itemsByPackage = new Dictionary<string, List<ITaskItem>> (StringComparer.OrdinalIgnoreCase);
       foreach (var item in CopyLocalItems) {
         var directory = Path.GetDirectoryName (item.ItemSpec);
         var directoryName = Path.GetFileName (directory);
         Log.LogMessage ($"{directoryName} -> {item.ItemSpec}");
-        if (directoryName.StartsWith ("netstandard2", StringComparison.OrdinalIgnoreCase)) {
-          var parent = Directory.GetParent (directory);
-          foreach (var nugetDirectory in parent.EnumerateDirectories ()) {
-            var name = Path.GetFileName (nugetDirectory.Name);
-            foreach (var fallback in PackageTargetFallback) {
-              if (!string.Equals (name, fallback, StringComparison.OrdinalIgnoreCase))
-                continue;
-              var fallbackDirectory = Path.Combine (parent.FullName, name);
-              fallbackDirectories.Add (fallbackDirectory);
-
-              // Remove the netstandard assembly, if there is a platform-specific one
-              var path = Path.Combine (fallbackDirectory, Path.GetFileName (item.ItemSpec));
-              if (File.Exists (path)) {
-                Log.LogMessage ($"Removing: {item.ItemSpec}");
-                assembliesToRemove.Add (item);
-              }
-            }
-          }
+        if (!directoryName.StartsWith ("netstandard2", StringComparison.OrdinalIgnoreCase))
+          continue;
+        var parent = Directory.GetParent (directory);
+        if (parent == null)
+          continue;
+        List<ITaskItem> list;
+        if (!itemsByPackage.TryGetValue (parent.FullName, out list)) {
+          list = new List<ITaskItem> ();
+          itemsByPackage [parent.FullName] = list;
         }
+        list.Add (item);
       }
 
-      // Look for any platform-specific assemblies
-      foreach (var directory in fallbackDirectories) {
-        foreach (var assembly in Directory.GetFiles (directory, "*.dll")) {
+      foreach (var package in itemsByPackage) {
+        var parentPath = package.Key;
+
+        // Pick exactly ONE fallback TFM for this package: the compatible candidate with the
+        // best (lowest) rank. Enumeration order is explicitly sorted first so the result is
+        // deterministic regardless of how the filesystem returns directories.
+        string selectedDirectory = null;
+        var selectedRank = int.MaxValue;
+
+        var candidates = Directory.EnumerateDirectories (parentPath)
+                                  .Select (d => Path.GetFileName (d))
+                                  .OrderBy (n => n, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in candidates) {
+          int candidateRank;
+          if (!rank.TryGetValue (name, out candidateRank))
+            continue;
+          if (candidateRank >= selectedRank)
+            continue;
+          selectedRank = candidateRank;
+          selectedDirectory = Path.Combine (parentPath, name);
+        }
+
+        if (selectedDirectory == null)
+          continue;
+
+        Log.LogMessage ($"Selected fallback '{Path.GetFileName (selectedDirectory)}' for {parentPath}");
+
+        // Remove the netstandard assembly only when the SELECTED directory supplies it, so a
+        // package is never left half-substituted.
+        foreach (var item in package.Value) {
+          var path = Path.Combine (selectedDirectory, Path.GetFileName (item.ItemSpec));
+          if (File.Exists (path)) {
+            Log.LogMessage ($"Removing: {item.ItemSpec}");
+            assembliesToRemove.Add (item);
+          }
+        }
+
+        // All substituted assemblies for this package come from that one directory.
+        foreach (var assembly in Directory.GetFiles (selectedDirectory, "*.dll")) {
           var assemblyName = Path.GetFileName (assembly);
           if (!assembliesToAdd.ContainsKey (assemblyName)) {
             Log.LogMessage ($"Adding: {assembly}");

--- a/workload/src/Samsung.Tizen.Build.Tasks/FixupNuGetReference.cs
+++ b/workload/src/Samsung.Tizen.Build.Tasks/FixupNuGetReference.cs
@@ -94,17 +94,20 @@ namespace Samsung.Tizen.Build.Tasks
 
         Log.LogMessage ($"Selected fallback '{Path.GetFileName (selectedDirectory)}' for {parentPath}");
 
-        // Remove the netstandard assembly only when the SELECTED directory supplies it, so a
-        // package is never left half-substituted.
+        // Replace the package's netstandard asset group ATOMICALLY - remove ALL of it, not
+        // just the files the fallback happens to share a name with.
+        //
+        // Removing only name-matching assets left the remaining netstandard DLLs in the
+        // reference set, so the build ended up with a mixture: some assemblies from the
+        // platform-specific TFM and some from netstandard, for the SAME package. That is the
+        // very mixing this selection is meant to prevent, and it silently reintroduces the
+        // netstandard build of any assembly the fallback group happens not to carry.
         foreach (var item in package.Value) {
-          var path = Path.Combine (selectedDirectory, Path.GetFileName (item.ItemSpec));
-          if (File.Exists (path)) {
-            Log.LogMessage ($"Removing: {item.ItemSpec}");
-            assembliesToRemove.Add (item);
-          }
+          Log.LogMessage ($"Removing: {item.ItemSpec}");
+          assembliesToRemove.Add (item);
         }
 
-        // All substituted assemblies for this package come from that one directory.
+        // ...and add the selected group's assets in their entirety.
         foreach (var assembly in Directory.GetFiles (selectedDirectory, "*.dll")) {
           var assemblyName = Path.GetFileName (assembly);
           if (!assembliesToAdd.ContainsKey (assemblyName)) {

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets
@@ -16,12 +16,43 @@ Copyright (c) Samsung All rights reserved.
 
   <PropertyGroup>
     <AssetTargetFallback></AssetTargetFallback>
+    <!--
+      Folder names that FixupNuGetReferences prefers over a package's netstandard2.x
+      assets. A package shipping both lib/netstandard2.0/ and lib/<tfm>/ only gets its
+      platform-specific assembly picked up when <tfm> is listed here, so this must cover
+      every (.NET major x Tizen platform) combination the workload supports - notably
+      net11.0-tizen11.0. Kept in sync with KnownRuntimePack x
+      TizenSdkSupportedTargetPlatformVersion by validate-workload-metadata.py check C8.
+    -->
     <PackageTargetFallback>
+      net11.0-tizen11.0;
+      net11.0-tizen10.1;
+      net11.0-tizen10.0;
+      net11.0-tizen9.0;
+      net11.0-tizen8.0;
+      net10.0-tizen11.0;
+      net10.0-tizen10.1;
       net10.0-tizen10.0;
+      net10.0-tizen9.0;
+      net10.0-tizen8.0;
+      net9.0-tizen11.0;
+      net9.0-tizen10.1;
       net9.0-tizen10.0;
-      net8.0-tizen10.0;
-      net8.0-tizen10.1;
+      net9.0-tizen9.0;
+      net9.0-tizen8.0;
       net8.0-tizen11.0;
+      net8.0-tizen10.1;
+      net8.0-tizen10.0;
+      net8.0-tizen9.0;
+      net8.0-tizen8.0;
+      net7.0-tizen11.0;
+      net7.0-tizen10.1;
+      net7.0-tizen10.0;
+      net7.0-tizen9.0;
+      net7.0-tizen8.0;
+      net6.0-tizen11.0;
+      net6.0-tizen10.1;
+      net6.0-tizen10.0;
       net6.0-tizen9.0;
       net6.0-tizen8.0;
       tizen10.0;

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.NuGet.targets
@@ -14,57 +14,90 @@ Copyright (c) Samsung All rights reserved.
 
   <UsingTask TaskName="Samsung.Tizen.Build.Tasks.FixupNuGetReferences" AssemblyFile="$(_TizenTaskAssemblyName)" />
 
+  <!--
+    Fallback TFM folder names that FixupNuGetReferences may substitute for a package's
+    netstandard2.x assets.
+
+    This MUST be filtered to what the project being built can actually consume. The task
+    matches a package's lib/<name>/ sibling directories against this list by NAME ONLY -
+    it performs no compatibility check of its own - so an unfiltered cross-product lets a
+    net6.0-tizen8.0 build silently pick up net6.0-tizen11.0 (newer platform) or
+    net11.0-tizen8.0 (newer .NET) assets.
+
+    A candidate is compatible only when BOTH:
+      * its .NET version is <= the project's .NET version, and
+      * its Tizen platform version is <= the project's platform version.
+
+    Candidates are appended highest-first so the best compatible match is added to the
+    task's directory set first and wins its first-wins assembly selection.
+
+    Legacy Tizen-only TFMs (tizen40 .. tizen10.0) carry no .NET version constraint and use
+    0.0 so they are filtered on platform version alone.
+
+    NOTE: this is deliberately built from conditional PROPERTIES rather than filtered
+    items. MSBuild evaluates all top-level properties before any items, so a property
+    referencing @(item) here would silently expand to nothing.
+
+    Kept in sync with KnownRuntimePack x TizenSdkSupportedTargetPlatformVersion by
+    validate-workload-metadata.py check C8; the filtering itself is pinned by
+    scripts/test-package-fallback.sh.
+  -->
+  <!-- BEGIN TIZEN PACKAGE FALLBACK (covered by scripts/test-package-fallback.sh) -->
   <PropertyGroup>
     <AssetTargetFallback></AssetTargetFallback>
-    <!--
-      Folder names that FixupNuGetReferences prefers over a package's netstandard2.x
-      assets. A package shipping both lib/netstandard2.0/ and lib/<tfm>/ only gets its
-      platform-specific assembly picked up when <tfm> is listed here, so this must cover
-      every (.NET major x Tizen platform) combination the workload supports - notably
-      net11.0-tizen11.0. Kept in sync with KnownRuntimePack x
-      TizenSdkSupportedTargetPlatformVersion by validate-workload-metadata.py check C8.
-    -->
-    <PackageTargetFallback>
-      net11.0-tizen11.0;
-      net11.0-tizen10.1;
-      net11.0-tizen10.0;
-      net11.0-tizen9.0;
-      net11.0-tizen8.0;
-      net10.0-tizen11.0;
-      net10.0-tizen10.1;
-      net10.0-tizen10.0;
-      net10.0-tizen9.0;
-      net10.0-tizen8.0;
-      net9.0-tizen11.0;
-      net9.0-tizen10.1;
-      net9.0-tizen10.0;
-      net9.0-tizen9.0;
-      net9.0-tizen8.0;
-      net8.0-tizen11.0;
-      net8.0-tizen10.1;
-      net8.0-tizen10.0;
-      net8.0-tizen9.0;
-      net8.0-tizen8.0;
-      net7.0-tizen11.0;
-      net7.0-tizen10.1;
-      net7.0-tizen10.0;
-      net7.0-tizen9.0;
-      net7.0-tizen8.0;
-      net6.0-tizen11.0;
-      net6.0-tizen10.1;
-      net6.0-tizen10.0;
-      net6.0-tizen9.0;
-      net6.0-tizen8.0;
-      tizen10.0;
-      tizen90;
-      tizen80;
-      tizen70;
-      tizen60;
-      tizen50;
-      tizen40;
-      $(PackageTargetFallback);
-    </PackageTargetFallback>
+
+    <!-- TargetFrameworkVersion is 'v11.0'-style; strip the leading v for comparison. -->
+    <_TizenFallbackNetVersion>$(TargetFrameworkVersion.TrimStart('vV'))</_TizenFallbackNetVersion>
+    <_TizenFallbackNetVersion Condition="'$(_TizenFallbackNetVersion)' == ''">0.0</_TizenFallbackNetVersion>
+    <_TizenFallbackPlatformVersion>$(TargetPlatformVersion)</_TizenFallbackPlatformVersion>
+    <_TizenFallbackPlatformVersion Condition="'$(_TizenFallbackPlatformVersion)' == ''">$(_DefaultTargetPlatformVersion)</_TizenFallbackPlatformVersion>
+    <_TizenFallbackPlatformVersion Condition="'$(_TizenFallbackPlatformVersion)' == ''">0.0</_TizenFallbackPlatformVersion>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net11.0-tizen11.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.1', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net11.0-tizen10.1</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net11.0-tizen10.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net11.0-tizen9.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net11.0-tizen8.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net10.0-tizen11.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.1', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net10.0-tizen10.1</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net10.0-tizen10.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net10.0-tizen9.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net10.0-tizen8.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net9.0-tizen11.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.1', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net9.0-tizen10.1</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net9.0-tizen10.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net9.0-tizen9.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net9.0-tizen8.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net8.0-tizen11.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.1', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net8.0-tizen10.1</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net8.0-tizen10.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net8.0-tizen9.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net8.0-tizen8.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('7.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net7.0-tizen11.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('7.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.1', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net7.0-tizen10.1</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('7.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net7.0-tizen10.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('7.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net7.0-tizen9.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('7.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net7.0-tizen8.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('6.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('11.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net6.0-tizen11.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('6.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.1', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net6.0-tizen10.1</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('6.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net6.0-tizen10.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('6.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net6.0-tizen9.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('6.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);net6.0-tizen8.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('0.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('10.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);tizen10.0</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('0.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('9.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);tizen90</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('0.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('8.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);tizen80</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('0.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('7.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);tizen70</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('0.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('6.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);tizen60</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('0.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('5.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);tizen50</_TizenFallbackList>
+    <_TizenFallbackList Condition="$([MSBuild]::VersionLessThanOrEquals('0.0', '$(_TizenFallbackNetVersion)')) And $([MSBuild]::VersionLessThanOrEquals('4.0', '$(_TizenFallbackPlatformVersion)'))">$(_TizenFallbackList);tizen40</_TizenFallbackList>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageTargetFallback>$(_TizenFallbackList.Trim(';'));$(PackageTargetFallback);</PackageTargetFallback>
+  </PropertyGroup>
+  <!-- END TIZEN PACKAGE FALLBACK -->
 
   <Target Name="_FixupNuGetReferences" AfterTargets="ResolvePackageAssets">
     <FixupNuGetReferences

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
@@ -28,6 +28,23 @@ Copyright (c) Samsung All rights reserved.
     />
   </ItemGroup>
 
+  <!--
+    Samsung.NETCore.App.Runtime.tizen is a placeholder runtime pack: it ships no runtime
+    binaries, because Tizen applications run against the runtime provided by the device
+    platform. A self-contained publish therefore cannot produce a working application - it
+    would emit an app with no runtime alongside it.
+
+    Fail with an actionable error instead of letting the build proceed. Set
+    SkipTizenSelfContainedCheck=true to bypass this if you are supplying a runtime by
+    other means.
+  -->
+  <Target Name="_TizenErrorOnSelfContained"
+          BeforeTargets="ProcessFrameworkReferences;ResolveRuntimePackAssets"
+          Condition=" '$(TargetPlatformIdentifier)' == 'tizen' And '$(SelfContained)' == 'true' And '$(SkipTizenSelfContainedCheck)' != 'true' ">
+    <Error Code="TIZENSDK001"
+           Text="Self-contained publishing is not supported for Tizen. Samsung.NETCore.App.Runtime.tizen is a placeholder runtime pack that contains no runtime binaries; Tizen applications run against the runtime provided by the device platform. Remove SelfContained=true (or set PublishSelfContained=false) and publish framework-dependent." />
+  </Target>
+
   <ItemGroup>
     <FrameworkReference Update="Microsoft.NETCore.App" RuntimePackLabels="Tizen" />
     <KnownRuntimePack Remove="Microsoft.NETCore.App" />

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
@@ -71,6 +71,14 @@ Copyright (c) Samsung All rights reserved.
                       RuntimePackRuntimeIdentifiers="tizen"
                       RuntimePackLabels="Tizen"
                       />
+    <KnownRuntimePack Include="Microsoft.NETCore.App"
+                      TargetFramework="net11.0"
+                      RuntimeFrameworkName="Microsoft.NETCore.App"
+                      LatestRuntimeFrameworkVersion="**FromWorkload**"
+                      RuntimePackNamePatterns="Samsung.NETCore.App.Runtime.**RID**"
+                      RuntimePackRuntimeIdentifiers="tizen"
+                      RuntimePackLabels="Tizen"
+                      />
   </ItemGroup>
 
 </Project>

--- a/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
+++ b/workload/src/Samsung.Tizen.Sdk/targets/Samsung.Tizen.Sdk.targets
@@ -37,10 +37,22 @@ Copyright (c) Samsung All rights reserved.
     Fail with an actionable error instead of letting the build proceed. Set
     SkipTizenSelfContainedCheck=true to bypass this if you are supplying a runtime by
     other means.
+
+    Gate on _SelfContainedWasSpecified, NOT on the final $(SelfContained) value. The .NET SDK
+    (Microsoft.NET.RuntimeIdentifierInference.targets) still *infers* SelfContained=true from a
+    present RuntimeIdentifier on pre-8.0 TFMs, and the Tizen SDK supplies an implicit RID
+    (tizen-x86) for MAUI apps. So an ordinary framework-dependent net6.0-tizen / net7.0-tizen
+    build - what every existing .NET MAUI Tizen consumer does - would have $(SelfContained)
+    inferred to 'true' and wrongly trip this guard. _SelfContainedWasSpecified is set by the SDK
+    only when SelfContained was *explicitly* requested (-p:SelfContained=true, or
+    PublishSelfContained=true during publish, which the SDK copies onto SelfContained before
+    computing _SelfContainedWasSpecified). Both are evaluated during project evaluation, before
+    this target runs. Verified empirically: net6.0/net7.0 infer SelfContained=true with
+    _SelfContainedWasSpecified empty; net8.0+ infer false; explicit requests set both true.
   -->
   <Target Name="_TizenErrorOnSelfContained"
           BeforeTargets="ProcessFrameworkReferences;ResolveRuntimePackAssets"
-          Condition=" '$(TargetPlatformIdentifier)' == 'tizen' And '$(SelfContained)' == 'true' And '$(SkipTizenSelfContainedCheck)' != 'true' ">
+          Condition=" '$(TargetPlatformIdentifier)' == 'tizen' And '$(SelfContained)' == 'true' And '$(_SelfContainedWasSpecified)' == 'true' And '$(SkipTizenSelfContainedCheck)' != 'true' ">
     <Error Code="TIZENSDK001"
            Text="Self-contained publishing is not supported for Tizen. Samsung.NETCore.App.Runtime.tizen is a placeholder runtime pack that contains no runtime binaries; Tizen applications run against the runtime provided by the device platform. Remove SelfContained=true (or set PublishSelfContained=false) and publish framework-dependent." />
   </Target>

--- a/workload/src/Samsung.Tizen.Templates/tizen/.template.config/template.json
+++ b/workload/src/Samsung.Tizen.Templates/tizen/.template.config/template.json
@@ -46,6 +46,10 @@
         {
           "choice": "net10.0",
           "description": "target framework version is net10.0-tizen"
+        },
+        {
+          "choice": "net11.0",
+          "description": "target framework version is net11.0-tizen (requires a .NET 11 SDK)"
         }
       ],
       "replaces": "net10.0",

--- a/workload/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj
+++ b/workload/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj
@@ -7,24 +7,39 @@
 
   <!--
     Tizen.UI.Components.Material ships assets for the tizen 10.0 platform band only, so
-    it is restorable from tizen 10.0 and later but not from the 8.0 / 9.0 bands. Resolve
-    the effective platform version here (an unversioned '-tizen' TFM leaves
-    TargetPlatformVersion empty until the workload SDK applies its default) and make
-    the reference conditional rather than mandatory.
+    it is restorable from tizen 10.0 and later but not from the 8.0 / 9.0 bands.
+
+    The platform version must be parsed out of $(TargetFramework) rather than read from
+    $(TargetPlatformVersion): PackageReference items are evaluated with the project body,
+    which runs BEFORE the SDK infers TargetPlatformVersion from the TFM. Reading it here
+    yields an empty string, which would silently fall back to the default and pull in an
+    incompatible Material for e.g. net11.0-tizen9.0.
+    BEGIN TIZEN UI PLATFORM DETECTION (covered by scripts/test-template-conditions.sh)
   -->
   <PropertyGroup>
-    <_TizenUIPlatformVersion>$(TargetPlatformVersion)</_TizenUIPlatformVersion>
+    <_TizenUIPlatformVersion>$([System.Text.RegularExpressions.Regex]::Match($(TargetFramework), '-tizen([0-9]+(\.[0-9]+)?)$').Groups[1].Value)</_TizenUIPlatformVersion>
+    <!-- Unversioned '-tizen' (or an outer multi-targeting build): assume the SDK default. -->
     <_TizenUIPlatformVersion Condition="'$(_TizenUIPlatformVersion)' == ''">10.0</_TizenUIPlatformVersion>
     <_TizenUIMaterialSupported>$([MSBuild]::VersionGreaterThanOrEquals('$(_TizenUIPlatformVersion)', '10.0'))</_TizenUIMaterialSupported>
   </PropertyGroup>
+  <!-- END TIZEN UI PLATFORM DETECTION -->
 
   <ItemGroup Condition="'$(_TizenUIMaterialSupported)' == 'true'">
     <PackageReference Include="Tizen.UI.Components.Material" Version="1.0.0-*" />
   </ItemGroup>
 
-  <Target Name="_ErrorIfTizenUIUnavailable" BeforeTargets="BeforeBuild"
-          Condition="'$(_TizenUIMaterialSupported)' != 'true'">
+  <!--
+    Re-check against the authoritative TargetPlatformVersion, which is available by the
+    time targets run. This both reports the real value and catches any drift between the
+    parsed and inferred platform version.
+  -->
+  <Target Name="_ErrorIfTizenUIUnavailable" BeforeTargets="BeforeBuild">
+    <PropertyGroup>
+      <_TizenUIEffectivePlatformVersion Condition="'$(TargetPlatformVersion)' != ''">$(TargetPlatformVersion)</_TizenUIEffectivePlatformVersion>
+      <_TizenUIEffectivePlatformVersion Condition="'$(_TizenUIEffectivePlatformVersion)' == ''">$(_TizenUIPlatformVersion)</_TizenUIEffectivePlatformVersion>
+    </PropertyGroup>
     <Error Code="TIZENTMPL001"
-           Text="This template's sources use Tizen.UI.Components.Material, which only ships assets for tizen10.0 and later (resolved TargetPlatformVersion: $(_TizenUIPlatformVersion)). Retarget the project to -tizen10.0 or later, or replace the Tizen.UI sources with a plain Tizen.NUI implementation." />
+           Condition="!$([MSBuild]::VersionGreaterThanOrEquals('$(_TizenUIEffectivePlatformVersion)', '10.0'))"
+           Text="This template's sources use Tizen.UI.Components.Material, which only ships assets for the tizen 10.0 platform band and later (resolved TargetPlatformVersion: $(_TizenUIEffectivePlatformVersion)). Retarget the project to a tizen 10.0 or later platform version, or replace the Tizen.UI sources with a plain Tizen.NUI implementation." />
   </Target>
 </Project>

--- a/workload/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj
+++ b/workload/src/Samsung.Tizen.Templates/tizen/TizenApp1.csproj
@@ -5,7 +5,26 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!--
+    Tizen.UI.Components.Material ships assets for the tizen 10.0 platform band only, so
+    it is restorable from tizen 10.0 and later but not from the 8.0 / 9.0 bands. Resolve
+    the effective platform version here (an unversioned '-tizen' TFM leaves
+    TargetPlatformVersion empty until the workload SDK applies its default) and make
+    the reference conditional rather than mandatory.
+  -->
+  <PropertyGroup>
+    <_TizenUIPlatformVersion>$(TargetPlatformVersion)</_TizenUIPlatformVersion>
+    <_TizenUIPlatformVersion Condition="'$(_TizenUIPlatformVersion)' == ''">10.0</_TizenUIPlatformVersion>
+    <_TizenUIMaterialSupported>$([MSBuild]::VersionGreaterThanOrEquals('$(_TizenUIPlatformVersion)', '10.0'))</_TizenUIMaterialSupported>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_TizenUIMaterialSupported)' == 'true'">
     <PackageReference Include="Tizen.UI.Components.Material" Version="1.0.0-*" />
   </ItemGroup>
+
+  <Target Name="_ErrorIfTizenUIUnavailable" BeforeTargets="BeforeBuild"
+          Condition="'$(_TizenUIMaterialSupported)' != 'true'">
+    <Error Code="TIZENTMPL001"
+           Text="This template's sources use Tizen.UI.Components.Material, which only ships assets for tizen10.0 and later (resolved TargetPlatformVersion: $(_TizenUIPlatformVersion)). Retarget the project to -tizen10.0 or later, or replace the Tizen.UI sources with a plain Tizen.NUI implementation." />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary

Adds .NET 11 support to the `tizen` workload alongside .NET 10, and repairs two install scripts that were committed corrupt on this branch.

> ### Base branch
>
> This PR targets **`net10.0`** because that is the active branch and it is already multi-band:
> `DOTNET_VERSION` selects the SDK band at build time, and `Versions.props` carries per-major
> arcade conditions. No `net11.0` branch exists today, so `net10.0` is the only branch this can
> land on.
>
> **If you would rather follow the per-major branch convention** (`net8.0` / `net9.0` / `net10.0`),
> create a `net11.0` branch and simply **retarget this PR to it — no changes to the commits are
> required**. The change set is additive and does not modify .NET 10 behaviour, so it applies
> cleanly either way. Say the word and I'll switch the base.

## Chosen TFM / API mapping

Primary TFM: **`net11.0-tizen11.0`** → TizenFX API level **15** → **`Samsung.Tizen.Ref.API15` `15.0.0.19396`** (already published).

`net11.0` combines with every declared platform version, so `net11.0-tizen{8.0,9.0,10.0,10.1,11.0}` all work.

**No new reference or runtime pack is required.** Ref packs ship `ref/net8.0` assemblies resolved by explicit `<File Path=…/>` entries in `data/FrameworkList.xml`, so they're independent of the consuming project's .NET version. `Samsung.Tizen.Ref.API16` does not exist and isn't needed.

SDK feature band: **`11.0.100-preview.7`** (latest .NET 11 SDK is `11.0.100-preview.7.26381.103`, 2026-08-11).

## Commit 1 — install script repair (independent of .NET 11)

Both installers were committed **truncated mid-statement and NUL-padded**, so the publicly `curl`'d installer could never complete:

- `workload-install.sh` ended at `for DOTNET_SDK in $INSTALLED_DOTNET_SD` + 134 NUL bytes
- `workload-install.ps1` ended inside its `catch` block at `Write-Host `

`validate-version-map.yml` didn't catch it because `Generate-InstallScripts.ps1` only compares the auto-generated version-map block — which was intact — so it reported **OK** for a file missing its tail. The generator now also asserts no NUL bytes and an expected final statement.

Also restores the SDK enumeration fix lost in the same regression: `--update-all-workloads` matched only `^6|^7`, silently ignoring every installed .NET 8/9/10/11 SDK.

## Commit 2 — .NET 11 support

| File | Change |
|---|---|
| `build/Versions.props` | arcade `11.0.0-beta.26426.103` for `11.0` bands |
| `NuGet.config` | add `dotnet11`; clear inherited `disabledPackageSources` |
| `Samsung.Tizen.Sdk.targets` | add the `net11.0` `KnownRuntimePack` (without it: NETSDK1082) |
| `RuntimeList.xml` | add the `.NET Runtime 11` row |
| `template.json` | offer `net11.0`; default stays `net10.0` while .NET 11 is preview |
| `TizenApp1.csproj` | `Tizen.UI.Components.Material` referenced conditionally on the resolved platform version, with an actionable `TIZENTMPL001` instead of an opaque NU1101 |
| `test-matrix.sh` | net11 rows; rows whose .NET major has no installed SDK are **skipped**, not failed, so the default .NET 10 run stays green |
| `validate-workload-metadata.py` | new C5/C6 checks tying template/matrix .NET majors to `KnownRuntimePack` + `RuntimeList.xml` |
| `test-version-band.sh` | **new** — asserts SDK version → feature band, and `.sh`/`.ps1` parity |
| `Makefile` | `validate-metadata`, `test-version-band`, aggregate `check` (no dotnet install needed) |
| `build-matrix.yml` | non-blocking .NET 11 preview leg |

`version-map.json` is **deliberately not updated** — it's a fallback cache of *already published* manifest versions, so an entry for an unreleased band would make the installer download a 404. Add it after the first release, as `10.0.300` was.

## Validation performed

Built the workload against the real .NET 11 preview SDK (`11.0.100-preview.7.26381.103`):

- `Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7` packs with the correct id, installs into `sdk-manifests/11.0.100-preview.7/`
- `dotnet new tizen --framework net11.0` + `dotnet build` produces `com.companyname.TizenApp1-1.0.0.tpk` for **both** `net11.0-tizen11.0` and `net11.0-tizen10.0`
- `net11.0-tizen11.0` verified to resolve `Samsung.Tizen.Ref.API15/15.0.0.19396`
- `make check`: 6/6 metadata checks, 36/36 version-band assertions, install-script drift + integrity all green
- C5/C6 confirmed by negative test (removing the net11 `KnownRuntimePack` / `RuntimeList` row fails the build)

Not run locally: `Samsung.Tizen.Ref.API13/14/15` packing, which needs `Tizen.NET.API*` from Samsung's GitHub Packages feed (403 without org membership). CI has `secrets.GITHUB_TOKEN` for this. The published equivalents were substituted to complete the end-to-end run.

## External blockers (not fixable here, not faked)

1. **`Samsung.NET.Sdk.Tizen.Manifest-11.0.100-preview.7` is unpublished.** Needs a `Release Workload` run with `net_sdk_version = 11.0.100-preview.7.26381.103`. Until then `workload-install.sh` finds no manifest on an 11.x SDK.
2. **`Tizen.UIExtensions.NUI`** (Samsung/Tizen.UIExtensions) — published `0.9.2` ships `lib/net6.0-tizen7.0` + `lib/tizen10.0`. TFM compatibility is fine; the blocker is its dependency group pinning `Microsoft.Maui.Graphics` `6.0.300-rc.3.1336`. Needs a release with `lib/net11.0-tizen11.0` built against API15 and refreshed MAUI Graphics deps.
3. **`Tizen.UI.Components.Material` `1.0.0-rc.8`** — ships only `lib/net8.0-tizen10.0`, never GA. Unusable below `tizen10.0`; handled in the template as described above.

Details, owners and expected artifact names in [`workload/docs/net11.md`](workload/docs/net11.md).

